### PR TITLE
fix: use jQuery 2.2.4 for compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
 
 <!-- Scripts
 –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
 <script src="./js/simpleCart.min.js"></script>
 <script src="./js/simpleStore.js"></script>
 <script src="./js/config.js"></script>


### PR DESCRIPTION
## Summary
- downgrade jQuery to 2.2.4 for `.success()` support

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689f8e76b46c8320bdd9c5cff3ca4b86