### PR TITLE
fix: update product data to use HTTPS and numeric prices

### DIFF
--- a/products.json
+++ b/products.json
@@ -1,34 +1,34 @@
 {
 	"products" : [
-		{
-			"name" : "Awesome T-shirt",
-			"price" : "35.99",
-			"options" : [
-				{ "Size" : "Small,Medium,Large" }
-			],
-			"image" : "http://upload.wikimedia.org/wikipedia/commons/c/c6/Grey_Tshirt.jpg",
-			"description" : "This is a very awesome grey T-shirt"
-		},
-		{
-			"name" : "Cool T-shirt",
-			"price" : "15.99",
-			"options" : [
-				{ "Size" : "Small,Medium,Large" },
-				{ "Color" : "Blue,Red" },
-			    { "OneOfAKind" : true }
-			],
-			"image" : "http://upload.wikimedia.org/wikipedia/commons/2/24/Blue_Tshirt.jpg",
-			"description" : "This is a really cool blue T-shirt",
-			"soldOut" : true
-		},
-		{
-			"name" : "Fun T-shirt",
-			"price" : "15.99",
-			"options" : [
-				{ "Size" : "Small,Medium,Large" }
-			],
-			"image" : "http://upload.wikimedia.org/wikipedia/commons/c/c6/Grey_Tshirt.jpg",
-			"description" : "This is another fun grey T-shirt"
-		}
-	]
+                {
+                        "name" : "Awesome T-shirt",
+                        "price" : 35.99,
+                        "options" : [
+                                { "Size" : "Small,Medium,Large" }
+                        ],
+                        "image" : "https://upload.wikimedia.org/wikipedia/commons/c/c6/Grey_Tshirt.jpg",
+                        "description" : "This is a very awesome grey T-shirt"
+                },
+                {
+                        "name" : "Cool T-shirt",
+                        "price" : 15.99,
+                        "options" : [
+                                { "Size" : "Small,Medium,Large" },
+                                { "Color" : "Blue,Red" },
+                            { "OneOfAKind" : true }
+                        ],
+                        "image" : "https://upload.wikimedia.org/wikipedia/commons/2/24/Blue_Tshirt.jpg",
+                        "description" : "This is a really cool blue T-shirt",
+                        "soldOut" : true
+                },
+                {
+                        "name" : "Fun T-shirt",
+                        "price" : 15.99,
+                        "options" : [
+                                { "Size" : "Small,Medium,Large" }
+                        ],
+                        "image" : "https://upload.wikimedia.org/wikipedia/commons/c/c6/Grey_Tshirt.jpg",
+                        "description" : "This is another fun grey T-shirt"
+                }
+        ]
 }


### PR DESCRIPTION
## Summary
- use HTTPS URLs for product images to avoid mixed-content issues
- store product prices as numbers to ensure proper parsing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689f91168cd88320b0f9d1723fcfe009