### PR TITLE
Fix cart summary with total calculation

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -94,7 +94,7 @@
   </footer>
 
   <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
-  <script src="/assets/js/simpleCart.min.js"></script>
+  <script src="/assets/js/simpleCart.min.js"></script>   <!-- must be before our page script -->
   <script src="/assets/js/simpleStore.js"></script>
   <script src="/assets/js/config.js"></script>
   <script src="/assets/js/cart-page.js"></script>


### PR DESCRIPTION
## Summary
- Use `simpleCart.total()` with NaN guard in cart summary and handle discounts/tax/free shipping display.
- Wire cart rendering to `ready`, `update`, and `afterAdd` events only, removing premature render.
- Clarify script load order in `cart.html` for proper simpleCart initialization.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689fa16fe028832085a7a2e89e534d03