### PR TITLE
Revamp cart page layout and logic

### DIFF
--- a/assets/css/cart.css
+++ b/assets/css/cart.css
@@ -8,12 +8,12 @@
   --muted:#90A4AE;
   --border:#E0E0E0;
 }
-
 *{box-sizing:border-box}
 html,body{margin:0;padding:0;color:var(--brand-text);font-family:Inter,system-ui,Arial,sans-serif;background:var(--brand-bg)}
 h1{font-family:"Playfair Display",serif;margin:24px 0 16px;font-size:28px}
 .container{width:100%;max-width:1120px;margin:0 auto;padding:0 16px}
 
+/* Header/footer */
 .site-header,.site-footer{background:#fff;border-bottom:1px solid var(--border)}
 .site-footer{border-top:1px solid var(--border);border-bottom:0;margin-top:48px}
 .site-header .container,.site-footer .container{display:flex;align-items:center;justify-content:space-between;height:60px}
@@ -22,12 +22,29 @@ h1{font-family:"Playfair Display",serif;margin:24px 0 16px;font-size:28px}
 .nav a{color:var(--brand-text);text-decoration:none;margin-left:16px;opacity:.85}
 .nav a.active,.nav a:hover{opacity:1}
 
-.cart-layout{display:grid;grid-template-columns:2fr 1fr;gap:24px}
-.cart-items{background:#fff;border:1px solid var(--border);border-radius:12px;overflow:hidden}
-.cart-head{display:grid;grid-template-columns:1fr 120px 160px 120px 24px;gap:12px;padding:12px 16px;border-bottom:1px solid var(--border);font-weight:600;color:#000}
+/* Main two-column layout */
+.cart-layout{
+  display:grid;
+  grid-template-columns: 1.4fr 1fr; /* items wider */
+  gap:24px;
+  align-items:start;
+}
+
+/* Items panel */
+.cart-items{
+  background:#fff;border:1px solid var(--border);border-radius:12px;overflow:hidden;
+}
+.cart-head{
+  display:grid;grid-template-columns:1fr 120px 160px 120px;gap:12px;
+  padding:12px 16px;border-bottom:1px solid var(--border);font-weight:600;color:#000;
+}
 .cart-rows{display:block}
-.row{display:grid;grid-template-columns:1fr 120px 160px 120px 24px;gap:12px;align-items:center;padding:16px;border-bottom:1px solid var(--border)}
+.row{
+  display:grid;grid-template-columns:1fr 120px 160px 120px;gap:12px;
+  align-items:center;padding:16px;border-bottom:1px solid var(--border);
+}
 .row:last-child{border-bottom:0}
+
 .item{display:flex;gap:12px;align-items:center}
 .thumb{width:64px;height:64px;border-radius:8px;object-fit:cover;border:1px solid var(--border);background:#fff}
 .title{font-weight:600}
@@ -35,13 +52,24 @@ h1{font-family:"Playfair Display",serif;margin:24px 0 16px;font-size:28px}
 .price,.line-total{font-weight:600}
 .hide-sm{display:block}
 
-.qty{display:inline-flex;align-items:center;border:1px solid var(--border);border-radius:10px;overflow:hidden}
+/* Quantity stepper */
+.qty{display:inline-flex;align-items:center;border:1px solid var(--border);border-radius:10px;overflow:visible}
 .qty button{all:unset;cursor:pointer;padding:6px 10px;line-height:1}
-.qty input{width:40px;text-align:center;border:0;border-left:1px solid var(--border);border-right:1px solid var(--border);padding:6px 0}
-.remove{cursor:pointer;color:var(--muted);font-size:18px}
+.qty input{
+  width:46px;text-align:center;border:0;border-left:1px solid var(--border);border-right:1px solid var(--border);padding:6px 0;
+  -moz-appearance:textfield;
+}
+.qty input::-webkit-outer-spin-button,
+.qty input::-webkit-inner-spin-button{ -webkit-appearance:none; margin:0; }
+
+.remove{cursor:pointer;color:var(--muted);margin-left:8px}
 .remove:hover{color:#000}
 
-.cart-summary .card{background:#fff;border:1px solid var(--border);border-radius:12px;padding:16px;position:sticky;top:16px}
+/* Summary card */
+.cart-summary .card{
+  position:sticky;top:16px;background:#fff;border:1px solid var(--border);
+  border-radius:12px;padding:16px;
+}
 .summary-line{display:flex;justify-content:space-between;align-items:center;padding:8px 0;border-bottom:1px dashed var(--border)}
 .summary-line:last-child{border-bottom:0}
 .coupon-block{padding:8px 0}
@@ -63,19 +91,19 @@ h1{font-family:"Playfair Display",serif;margin:24px 0 16px;font-size:28px}
 .btn-lg{padding:14px 18px;font-size:16px}
 .w-100{width:100%}
 .hidden{display:none}
-
+.link{color:var(--brand-accent);text-decoration:none}
+.continue-mobile{margin-top:8px;text-align:center}
 .empty{padding:24px;text-align:center}
 
+/* Responsive */
 @media (max-width:991px){
   .cart-layout{grid-template-columns:1fr}
-  .cart-head{grid-template-columns:1fr 100px 140px 100px 24px}
-  .row{grid-template-columns:1fr 100px 140px 100px 24px}
+  .cart-head,.row{grid-template-columns:1fr 100px 150px 100px}
   .hide-sm{display:none}
 }
 @media (max-width:575px){
-  .cart-head{display:none}
-  .row{grid-template-columns:1fr 80px 120px 80px 24px;padding:12px}
-  .thumb{width:48px;height:48px}
-  .qty button{padding:6px 8px}
-  .qty input{width:32px}
+  .row{grid-template-columns:1fr 90px 140px 90px}
+  .thumb{width:56px;height:56px}
+  h1{font-size:24px}
+  .grand-amount{font-size:20px}
 }

--- a/assets/js/cart-page.js
+++ b/assets/js/cart-page.js
@@ -1,102 +1,85 @@
-const TAX_RATE = 0.10;
-const FREE_SHIP_THRESHOLD = 100;
+/* Cart page logic for 4D Cosmetics */
+(function($){
+  "use strict";
 
-const coupons = {
-  'WELCOME10': { type: 'percent', value: 10 },
-  'OFF50': { type: 'flat', value: 50 }
-};
+  // ---- Config ----
+  var TAX_RATE = 0.10;                  // 10%
+  var FREE_SHIP_THRESHOLD = 100;        // USD
+  var COUPONS = {
+    "WELCOME10": { type: "percent", value: 10 },
+    "OFF50":     { type: "flat",    value: 50 }
+  };
+  var LS_COUPON_KEY = "cart_applied_coupon";
 
-$(function () {
-  const $rows = $('#cart-rows');
-  const $empty = $('#empty-state');
-  let appliedCoupon = localStorage.getItem('couponCode') || '';
+  function fmt(n){ return "$" + (Math.round(n * 100) / 100).toFixed(2); }
 
-  function formatCurrency(n) {
-    return '$' + Number(n).toFixed(2);
+  function getAppliedCoupon(){
+    var code = (localStorage.getItem(LS_COUPON_KEY) || "").trim().toUpperCase();
+    return code && COUPONS[code] ? { code: code, rule: COUPONS[code] } : null;
+  }
+  function setAppliedCoupon(code){
+    if(code){ localStorage.setItem(LS_COUPON_KEY, code.toUpperCase()); }
+    else { localStorage.removeItem(LS_COUPON_KEY); }
+  }
+  function computeDiscount(subtotal){
+    var applied = getAppliedCoupon();
+    if(!applied) return { amount: 0, label: "" };
+    var rule = applied.rule, val = 0;
+    if(rule.type === "percent") val = subtotal * (rule.value/100);
+    if(rule.type === "flat")    val = rule.value;
+    return { amount: Math.min(val, subtotal), label: applied.code };
   }
 
-  function fmt(n) {
-    return formatCurrency(n);
-  }
+  function renderCart(){
+    var $rows = $("#cart-rows").empty();
+    var count = simpleCart.quantity();
+    $("#cart-count").text(count);
 
-  function renderItems() {
-    const items = simpleCart.items();
-    $rows.empty();
-    if (items.length === 0) {
-      $('.cart-head').addClass('hidden');
-      $empty.removeClass('hidden');
-      $('#cart-count').text(0);
-      return;
+    $("#checkout-btn").prop("disabled", count === 0);
+
+    if(count === 0){
+      $("#empty-state").removeClass("hidden");
+      $(".cart-head").addClass("hidden");
+    } else {
+      $("#empty-state").addClass("hidden");
+      $(".cart-head").removeClass("hidden");
     }
-    $('.cart-head').removeClass('hidden');
-    $empty.addClass('hidden');
 
-    items.forEach(item => {
-      const row = $('<div class="row"></div>').attr('data-id', item.id());
+    simpleCart.each(function(item){
+      var id     = item.id();
+      var name   = item.get("name") || "Product";
+      var price  = +item.get("price") || 0;
+      var image  = item.get("image") || "/assets/img/products/placeholder.jpg";
+      var desc   = item.get("description") || "";
+      var qty    = item.quantity();
+      var total  = price * qty;
 
-      const itemCol = $('<div class="item"></div>');
-      const thumb = $('<img class="thumb" alt="">').attr('src', item.get('thumb') || item.get('image') || '').attr('alt', item.get('name'));
-      const info = $('<div class="info"></div>');
-      const title = $('<div class="title"></div>').text(item.get('name'));
-      const metaText = item.get('description') || item.get('meta') || '';
-      const meta = $('<div class="meta"></div>').text(metaText);
-      info.append(title);
-      if (metaText) info.append(meta);
-      itemCol.append(thumb, info);
+      var $row = $('<div class="row" data-id="'+id+'">\
+        <div class="item">\
+          <img class="thumb" alt="'+$("<div>").text(name).html()+'" src="'+image+'">\
+          <div class="stack">\
+            <div class="title">'+name+'</div>\
+            <div class="meta">'+desc+'</div>\
+          </div>\
+          <span class="remove" title="Remove" aria-label="Remove" role="button">&times;</span>\
+        </div>\
+        <div class="price hide-sm">'+fmt(price)+'</div>\
+        <div class="qty">\
+          <button class="btn-minus" aria-label="Decrease">−</button>\
+          <input class="qty-input" type="number" min="0" step="1" value="'+qty+'">\
+          <button class="btn-plus" aria-label="Increase">+</button>\
+        </div>\
+        <div class="line-total">'+fmt(total)+'</div>\
+      </div>');
 
-      const priceCol = $('<div class="price"></div>').text(formatCurrency(item.get('price')));
-
-      const qtyCol = $('<div class="qty"></div>');
-      const minus = $('<button type="button">-</button>');
-      const qtyInput = $('<input type="text" inputmode="numeric">').val(item.get('quantity'));
-      const plus = $('<button type="button">+</button>');
-      qtyCol.append(minus, qtyInput, plus);
-
-      const totalCol = $('<div class="line-total"></div>').text(formatCurrency(item.total()));
-
-      const removeCol = $('<div class="remove" title="Remove">×</div>');
-
-      row.append(itemCol, priceCol, qtyCol, totalCol, removeCol);
-      $rows.append(row);
-
-      minus.on('click', function () {
-        const q = item.get('quantity') - 1;
-        if (q <= 0) item.remove();
-        else item.set('quantity', q);
-        simpleCart.update();
-      });
-      plus.on('click', function () {
-        item.set('quantity', item.get('quantity') + 1);
-        simpleCart.update();
-      });
-      qtyInput.on('change', function () {
-        let val = parseInt(qtyInput.val(), 10);
-        if (isNaN(val) || val <= 0) {
-          item.remove();
-        } else {
-          item.set('quantity', val);
-        }
-        simpleCart.update();
-      });
-      removeCol.on('click', function () {
-        item.remove();
-        simpleCart.update();
-      });
+      $rows.append($row);
     });
 
-    $('#cart-count').text(simpleCart.quantity());
-  }
-
-  function computeDiscount(subtotal) {
-    if (!appliedCoupon || !coupons[appliedCoupon]) return { amount: 0, label: '' };
-    const c = coupons[appliedCoupon];
-    let amount = c.type === 'percent' ? subtotal * (c.value / 100) : c.value;
-    amount = Math.min(amount, subtotal);
-    return { amount, label: appliedCoupon };
+    updateSummary();
   }
 
   function updateSummary(){
-    var subtotal = +simpleCart.total() || 0;
+    var subtotal = +simpleCart.total() || 0; // <-- correct API for this build
 
     var discountObj = computeDiscount(subtotal);
     var discount = discountObj.amount;
@@ -105,71 +88,91 @@ $(function () {
     var tax = taxBase * TAX_RATE;
     var grand = Math.max(0, taxBase + tax);
 
-    $('#summary-subtotal').text(fmt(subtotal));
-
-    if (discount > 0){
-      $('#discount-line').removeClass('hidden');
-      $('#summary-discount').text('-' + fmt(discount).replace('$','$'));
-      $('#coupon-msg').text('Applied: ' + discountObj.label).css('color','var(--brand-success)');
-    } else {
-      $('#discount-line').addClass('hidden');
-      $('#coupon-msg').text('').css('color','');
+    $("#summary-subtotal").text(fmt(subtotal));
+    if(discount > 0){
+      $("#discount-line").removeClass("hidden");
+      $("#summary-discount").text("-" + fmt(discount).replace("$","$"));
+      $("#coupon-msg").text("Applied: " + discountObj.label);
+    }else{
+      $("#discount-line").addClass("hidden");
+      $("#coupon-msg").text("");
     }
-
-    $('#summary-tax').text(fmt(tax));
-    $('#summary-grand').text(fmt(grand));
+    $("#summary-tax").text(fmt(tax));
+    $("#summary-grand").text(fmt(grand));
 
     var progress = Math.max(0, Math.min(100, (subtotal / FREE_SHIP_THRESHOLD) * 100));
-    $('#fs-bar').css('width', progress + '%');
-    if (subtotal >= FREE_SHIP_THRESHOLD){
-      $('#fs-msg').text("Congrats, you're eligible for Free Shipping");
+    $("#fs-bar").css("width", progress + "%");
+    if(subtotal >= FREE_SHIP_THRESHOLD){
+      $("#fs-msg").text("Congrats, you're eligible for Free Shipping");
     } else {
       var remain = FREE_SHIP_THRESHOLD - subtotal;
-      $('#fs-msg').text('Spend ' + fmt(remain) + ' more to get Free Shipping');
+      $("#fs-msg").text("Spend " + fmt(remain) + " more to get Free Shipping");
     }
   }
 
-  function renderCart() {
-    renderItems();
+  function applyCoupon(code){
+    code = (code || "").trim().toUpperCase();
+    if(!code){
+      $("#coupon-msg").text("Enter a code."); setAppliedCoupon(null); updateSummary(); return;
+    }
+    if(!COUPONS[code]){
+      $("#coupon-msg").text("Invalid code."); setAppliedCoupon(null);
+    } else {
+      $("#coupon-msg").text("Applied: " + code); setAppliedCoupon(code);
+    }
     updateSummary();
   }
 
-  $('#apply-coupon').on('click', function () {
-    const code = $('#coupon-input').val().trim().toUpperCase();
-    if (!code) return;
-    if (!coupons[code]) {
-      appliedCoupon = '';
-      localStorage.removeItem('couponCode');
-      renderCart();
-      $('#coupon-msg').text('Invalid coupon code').css('color', 'var(--brand-danger)');
-    } else {
-      appliedCoupon = code;
-      localStorage.setItem('couponCode', code);
-      renderCart();
-    }
-  });
-
-  if (appliedCoupon) {
-    $('#coupon-input').val(appliedCoupon);
-  }
-
-  $('#checkout-btn').on('click', function () {
-    try {
-      simpleCart.checkout();
-    } catch (e) {
-      const items = [];
-      simpleCart.each(function (item) {
-        items.push({ name: item.get('name'), price: item.get('price'), quantity: item.get('quantity') });
-      });
-      if (window.location.pathname !== '/checkout.html') {
-        window.location.href = '/checkout.html';
-      } else {
-        alert('TODO: Configure checkout\n\n' + JSON.stringify(items));
+  // Events
+  $(document)
+    .on("click", ".btn-plus", function(){
+      var id = $(this).closest(".row").data("id");
+      var item = simpleCart.find({ id: id })[0];
+      if(item){ item.increment(); renderCart(); }
+    })
+    .on("click", ".btn-minus", function(){
+      var id = $(this).closest(".row").data("id");
+      var item = simpleCart.find({ id: id })[0];
+      if(item){
+        if(item.quantity() <= 1){ item.remove(); }
+        else { item.decrement(); }
+        renderCart();
       }
+    })
+    .on("change", ".qty-input", function(){
+      var id = $(this).closest(".row").data("id");
+      var val = Math.max(0, parseInt($(this).val(), 10) || 0);
+      var item = simpleCart.find({ id: id })[0];
+      if(item){
+        if(val <= 0) item.remove();
+        else item.quantity(val);
+        renderCart();
+      }
+    })
+    .on("click", ".remove", function(){
+      var id = $(this).closest(".row").data("id");
+      var item = simpleCart.find({ id: id })[0];
+      if(item){ item.remove(); renderCart(); }
+    });
+
+  $("#apply-coupon").on("click", function(){ applyCoupon($("#coupon-input").val()); });
+  $("#coupon-input").on("keypress", function(e){ if(e.which === 13){ $("#apply-coupon").click(); } });
+
+  $("#checkout-btn").on("click", function(){
+    try{
+      if(typeof simpleCart.checkout === "function"){ simpleCart.checkout(); }
+      else { alert("Checkout not configured in this demo.\nTotal: " + $("#summary-grand").text()); }
+    }catch(err){
+      console.error(err); alert("Checkout is unavailable right now.");
     }
   });
 
-  simpleCart.bind('update', renderCart);
-  simpleCart.bind('ready', renderCart);
-  simpleCart.bind('afterAdd', renderCart);
-});
+  // Bind to simpleCart lifecycle
+  simpleCart.bind("ready", renderCart);
+  simpleCart.bind("update", renderCart);
+  simpleCart.bind("afterAdd", renderCart);
+
+  // Initial render after DOM ready
+  $(function(){ var c = getAppliedCoupon(); if(c){ $("#coupon-input").val(c.code); } renderCart(); });
+
+})(jQuery);

--- a/cart.html
+++ b/cart.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>Your Cart • 4D Cosmetics</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Playfair+Display:wght@600&display=swap" rel="stylesheet">
+  <link rel="icon" type="image/png" href="/assets/img/favicon.png">
   <link rel="stylesheet" href="/assets/css/cart.css">
 </head>
 <body>
@@ -23,17 +24,15 @@
   <main class="container cart-layout">
     <h1>Your Cart (<span id="cart-count">0</span> items)</h1>
 
+    <!-- LEFT: items panel -->
     <section class="cart-items">
       <div class="cart-head row">
         <div>Item</div>
         <div class="hide-sm">Price</div>
         <div>Quantity</div>
         <div>Total</div>
-        <div></div>
       </div>
-      <div id="cart-rows" class="cart-rows">
-        <!-- JS renders rows here -->
-      </div>
+      <div id="cart-rows" class="cart-rows"></div>
 
       <div id="empty-state" class="empty hidden">
         <p>Your cart is empty.</p>
@@ -41,6 +40,7 @@
       </div>
     </section>
 
+    <!-- RIGHT: summary card -->
     <aside class="cart-summary">
       <div class="card">
         <div class="summary-line">
@@ -55,6 +55,7 @@
             <button id="apply-coupon" class="btn btn-outline">Apply</button>
           </div>
           <div id="coupon-msg" class="coupon-msg"></div>
+
           <div id="discount-line" class="summary-line hidden">
             <span>Discount:</span>
             <span id="summary-discount">-$0.00</span>
@@ -78,7 +79,11 @@
           </div>
         </div>
 
-        <button id="checkout-btn" class="btn btn-primary btn-lg w-100">Check out</button>
+        <button id="checkout-btn" class="btn btn-primary btn-lg w-100" disabled>Check out</button>
+
+        <div class="continue-mobile">
+          <a href="/products.html" class="link">Continue shopping</a>
+        </div>
       </div>
     </aside>
   </main>
@@ -93,8 +98,9 @@
     </div>
   </footer>
 
+  <!-- Required script order -->
   <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
-  <script src="/assets/js/simpleCart.min.js"></script>   <!-- must be before our page script -->
+  <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/simpleStore.js"></script>
   <script src="/assets/js/config.js"></script>
   <script src="/assets/js/cart-page.js"></script>


### PR DESCRIPTION
## Summary
- Refresh cart page with two-column layout and sticky summary panel
- Style cart with responsive grid, improved quantity steppers, and coupon UI
- Update cart logic to use `simpleCart.total()` and handle discounts, tax, and free shipping progress

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689fa404e35c8320a89605f608bf0aac