### PR TITLE
Revamp cart layout and styles

### DIFF
--- a/assets/css/cart.css
+++ b/assets/css/cart.css
@@ -5,10 +5,9 @@
   --brand-success:#43A047;
   --brand-danger:#E53935;
   --brand-warning:#FB8C00;
-  --muted:#90A4AE;
+  --muted:#6B7C88;
   --border:#E0E0E0;
 }
-
 *{box-sizing:border-box}
 html,body{margin:0;padding:0;color:var(--brand-text);font-family:Inter,system-ui,Arial,sans-serif;background:var(--brand-bg)}
 h1{font-family:"Playfair Display",serif;margin:24px 0 16px;font-size:28px}
@@ -23,38 +22,45 @@ h1{font-family:"Playfair Display",serif;margin:24px 0 16px;font-size:28px}
 .nav a.active,.nav a:hover{opacity:1}
 
 .cart-layout{display:grid;grid-template-columns:2fr 1fr;gap:24px}
-.cart-items{background:#fff;border:1px solid var(--border);border-radius:12px;overflow:hidden}
-.cart-head{display:grid;grid-template-columns:1fr 120px 160px 120px 24px;gap:12px;padding:12px 16px;border-bottom:1px solid var(--border);font-weight:600;color:#000}
-.cart-rows{display:block}
-.row{display:grid;grid-template-columns:1fr 120px 160px 120px 24px;gap:12px;align-items:center;padding:16px;border-bottom:1px solid var(--border)}
-.row:last-child{border-bottom:0}
-.item{display:flex;gap:12px;align-items:center}
-.thumb{width:64px;height:64px;border-radius:8px;object-fit:cover;border:1px solid var(--border);background:#fff}
-.title{font-weight:600}
-.meta{color:var(--muted);font-size:12px;margin-top:2px}
+.cart-items{background:#fff;border:1px solid var(--border);border-radius:12px;padding:16px}
+.cart-rows{display:flex;flex-direction:column;gap:8px}
+.row{display:grid;grid-template-columns:1fr 100px 160px 100px 80px;gap:12px;align-items:center;padding:12px 16px;border:1px solid var(--border);border-radius:12px;transition:box-shadow .2s,border-color .2s;background:#fff}
+.row:hover{box-shadow:0 0 0 2px var(--brand-accent)}
+.item{display:flex;gap:12px;align-items:center;min-width:0}
+.thumb{width:96px;height:96px;border-radius:8px;object-fit:cover;border:1px solid var(--border);background:#fff}
+.title{font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.meta{color:var(--muted);font-size:12px;margin-top:2px;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
 .price,.line-total{font-weight:600}
-.hide-sm{display:block}
 
 .qty{display:inline-flex;align-items:center;border:1px solid var(--border);border-radius:10px;overflow:hidden}
-.qty button{all:unset;cursor:pointer;padding:6px 10px;line-height:1}
-.qty input{width:40px;text-align:center;border:0;border-left:1px solid var(--border);border-right:1px solid var(--border);padding:6px 0}
-.remove{cursor:pointer;color:var(--muted);font-size:18px}
-.remove:hover{color:#000}
+.qty button{all:unset;cursor:pointer;padding:8px 12px;line-height:1}
+.qty input{width:40px;text-align:center;border:0;border-left:1px solid var(--border);border-right:1px solid var(--border);padding:8px 0}
+.qty-warning{font-size:12px;color:var(--brand-warning);margin-top:4px}
+.row-actions{display:flex;gap:8px;justify-content:flex-end}
+.row-actions .btn-link{background:none;border:0;color:var(--brand-accent);cursor:pointer;padding:4px 8px;font-size:14px}
 
 .cart-summary .card{background:#fff;border:1px solid var(--border);border-radius:12px;padding:16px;position:sticky;top:16px}
+.cart-summary h2{font-size:22px;margin:0 0 8px}
 .summary-line{display:flex;justify-content:space-between;align-items:center;padding:8px 0;border-bottom:1px dashed var(--border)}
 .summary-line:last-child{border-bottom:0}
 .coupon-block{padding:8px 0}
 .coupon-row{display:flex;gap:8px;margin-top:6px}
 .coupon-row input{flex:1;padding:10px;border:1px solid var(--border);border-radius:10px}
 .coupon-msg{font-size:12px;color:var(--muted);margin-top:6px}
+.coupon-chip{display:inline-flex;align-items:center;background:var(--brand-bg);border-radius:16px;padding:4px 8px;font-size:12px;margin-top:6px}
+.coupon-chip button{background:none;border:0;margin-left:4px;cursor:pointer}
+.ship-block{margin:16px 0}
+.ship-option{display:flex;flex-direction:column;margin-bottom:8px;font-size:14px}
+.ship-option .eta{font-size:12px;color:var(--muted)}
+.ship-option .helper{font-style:normal;color:var(--muted)}
+
 .grand-total{display:flex;justify-content:space-between;align-items:center;margin:10px 0 12px}
 .grand-amount{font-size:22px;font-weight:700}
 
 .free-ship{margin:8px 0 16px}
 .fs-msg{font-size:12px;color:var(--muted);margin-bottom:6px}
 .progress{height:8px;background:#f0f3f5;border-radius:999px;overflow:hidden}
-.progress-bar{height:100%;background:var(--brand-success);width:0%}
+.progress-bar{height:100%;background:var(--brand-success);width:0%;transition:width .3s}
 
 .btn{display:inline-flex;align-items:center;justify-content:center;border-radius:10px;border:1px solid transparent;padding:10px 14px;font-weight:600;cursor:pointer;user-select:none;text-decoration:none}
 .btn-primary{background:var(--brand-accent);color:#fff;border-color:var(--brand-accent)}
@@ -64,18 +70,34 @@ h1{font-family:"Playfair Display",serif;margin:24px 0 16px;font-size:28px}
 .w-100{width:100%}
 .hidden{display:none}
 
-.empty{padding:24px;text-align:center}
+button:focus,input:focus{outline:2px solid var(--brand-accent);outline-offset:2px}
+.visually-hidden{position:absolute!important;height:1px;width:1px;overflow:hidden;clip:rect(1px,1px,1px,1px)}
+
+.mobile-cta{position:fixed;bottom:0;left:0;right:0;background:#fff;border-top:1px solid var(--border);padding:8px 16px;display:flex;align-items:center;gap:16px;z-index:20}
+.mobile-cta .mobile-total{flex:1;display:flex;justify-content:space-between;font-weight:600}
+.mobile-cta button{flex:1}
+
+.toast-region{position:fixed;bottom:16px;left:16px;z-index:30}
+.toast{background:#333;color:#fff;padding:8px 12px;border-radius:6px;margin-top:8px;font-size:14px}
+.toast button{background:none;border:0;color:#fff;text-decoration:underline;margin-left:8px;cursor:pointer}
+
+.modal{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:40}
+.modal-content{background:#fff;padding:24px;border-radius:12px;max-width:500px;width:100%;max-height:80vh;overflow:auto}
+.modal-actions{display:flex;gap:8px;margin-top:16px;justify-content:flex-end}
+
+@media (min-width:992px){
+  .mobile-cta{display:none}
+}
 
 @media (max-width:991px){
   .cart-layout{grid-template-columns:1fr}
-  .cart-head{grid-template-columns:1fr 100px 140px 100px 24px}
-  .row{grid-template-columns:1fr 100px 140px 100px 24px}
-  .hide-sm{display:none}
+  .cart-summary .card{position:static}
+  .row{grid-template-columns:1fr 80px 120px 80px 60px}
 }
+
 @media (max-width:575px){
-  .cart-head{display:none}
-  .row{grid-template-columns:1fr 80px 120px 80px 24px;padding:12px}
-  .thumb{width:48px;height:48px}
+  .row{grid-template-columns:1fr 60px 120px 80px 60px;padding:12px}
+  .thumb{width:64px;height:64px}
   .qty button{padding:6px 8px}
   .qty input{width:32px}
 }

--- a/cart.html
+++ b/cart.html
@@ -24,64 +24,91 @@
     <h1>Your Cart (<span id="cart-count">0</span> items)</h1>
 
     <section class="cart-items">
-      <div class="cart-head row">
-        <div>Item</div>
-        <div class="hide-sm">Price</div>
-        <div>Quantity</div>
-        <div>Total</div>
-        <div></div>
-      </div>
-      <div id="cart-rows" class="cart-rows">
-        <!-- JS renders rows here -->
-      </div>
+      <div id="cart-rows" class="cart-rows"><!-- JS renders rows --></div>
 
       <div id="empty-state" class="empty hidden">
         <p>Your cart is empty.</p>
         <a class="btn btn-primary" href="/products.html">Continue shopping</a>
       </div>
+
+      <section id="saved-for-later" class="saved hidden">
+        <h2>Saved for later</h2>
+        <div class="saved-rows"></div>
+      </section>
     </section>
 
     <aside class="cart-summary">
       <div class="card">
+        <h2>Order Summary</h2>
         <div class="summary-line">
           <span>Subtotal:</span>
-          <span id="summary-subtotal">$0.00</span>
+          <span id="subtotal-value">$0.00</span>
+        </div>
+        <div id="discount-row" class="summary-line hidden">
+          <span>Discount:</span>
+          <span id="discount-value">-$0.00</span>
+        </div>
+        <div class="summary-line">
+          <span>Shipping:</span>
+          <span id="shipping-value">$0.00</span>
+        </div>
+        <div class="summary-line">
+          <span>Tax:</span>
+          <span id="tax-value">$0.00</span>
+        </div>
+        <div class="summary-line grand-total">
+          <strong>Total:</strong>
+          <strong id="grandtotal-value">$0.00</strong>
         </div>
 
-        <div id="coupon-block" class="coupon-block">
+        <div class="coupon-block">
           <label for="coupon-input">Coupon Code</label>
           <div class="coupon-row">
             <input id="coupon-input" type="text" placeholder="Enter code">
-            <button id="apply-coupon" class="btn btn-outline">Apply</button>
+            <button id="coupon-apply" class="btn btn-outline">Apply</button>
           </div>
-          <div id="coupon-msg" class="coupon-msg"></div>
-          <div id="discount-line" class="summary-line hidden">
-            <span>Discount:</span>
-            <span id="summary-discount">-$0.00</span>
-          </div>
+          <div id="coupon-feedback" aria-live="polite" class="coupon-msg"></div>
+          <div id="coupon-chip" class="coupon-chip hidden"><span class="code"></span><button type="button" aria-label="Remove coupon">×</button></div>
         </div>
 
-        <div class="summary-line">
-          <span>Sales Tax (10%):</span>
-          <span id="summary-tax">$0.00</span>
-        </div>
-
-        <div class="grand-total">
-          <div>Grand total:</div>
-          <div id="summary-grand" class="grand-amount">$0.00</div>
+        <div id="shipping-methods" class="ship-block">
+          <h2>Shipping</h2>
+          <label class="ship-option"><input type="radio" name="shippingMethod" value="standard6_99" checked> <span>Standard $6.99</span><small class="eta"></small></label>
+          <label class="ship-option"><input type="radio" name="shippingMethod" value="free_standard" disabled> <span>Free Standard (4–6 business days) <em class="helper">Free over $100</em></span><small class="eta"></small></label>
+          <label class="ship-option"><input type="radio" name="shippingMethod" value="express9_99"> <span>Express $9.99</span><small class="eta"></small></label>
+          <label class="ship-option"><input type="radio" name="shippingMethod" value="overnight24_99"> <span>Overnight $24.99</span><small class="eta"></small></label>
         </div>
 
         <div class="free-ship">
-          <div id="fs-msg" class="fs-msg">Spend $100.00 more to get Free Shipping</div>
-          <div class="progress">
-            <div id="fs-bar" class="progress-bar" style="width:0%"></div>
-          </div>
+          <div id="fs-text" class="fs-msg">You're $100.00 away from free shipping</div>
+          <div class="progress"><div id="fs-bar" class="progress-bar" style="width:0%"></div></div>
         </div>
 
         <button id="checkout-btn" class="btn btn-primary btn-lg w-100">Check out</button>
       </div>
     </aside>
   </main>
+
+  <div id="mobile-cta" class="mobile-cta">
+    <div class="mobile-total"><span>Total</span><span id="mobile-total">$0.00</span></div>
+    <button id="mobile-checkout" class="btn btn-primary w-100">Proceed to Checkout</button>
+  </div>
+
+  <div id="checkout-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="checkout-title">
+    <div class="modal-content" tabindex="-1">
+      <h2 id="checkout-title">Order Summary</h2>
+      <div id="modal-items"></div>
+      <div id="modal-totals"></div>
+      <div class="modal-actions">
+        <button id="modal-email" class="btn btn-primary">Proceed via Email</button>
+        <button id="modal-copy" class="btn btn-outline">Copy order summary</button>
+        <button id="modal-cancel" class="btn">Cancel</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="live-updates" role="status" aria-live="polite" class="visually-hidden"></div>
+  <div id="toast-region" role="status" aria-live="polite" class="toast-region"></div>
 
   <footer class="site-footer">
     <div class="container">


### PR DESCRIPTION
## Summary
- overhaul cart markup with saved-for-later section, coupon and shipping UI, and checkout modal placeholders
- add responsive styles, sticky summary card, mobile CTA bar, and progress visuals

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689fa7666b608320b23e791b1cf2ac46