### PR TITLE
feat: add flexible checkout options

### DIFF
--- a/assets/css/checkout.css
+++ b/assets/css/checkout.css
@@ -1,0 +1,7 @@
+.pm-tabs{display:flex;gap:.5rem;margin:.5rem 0;}
+.pm-tabs button{padding:.4rem .75rem;border:1px solid #ccc;background:#f8f8f8;cursor:pointer;}
+.pm-tabs button[aria-selected="true"]{background:#fff;border-bottom:2px solid var(--brand-primary,#333);}
+.pm-tabs button:focus{outline:2px solid var(--brand-primary,#333);outline-offset:2px;}
+.pm-option{display:block;margin:.25rem 0;}
+.pm-feedback{margin-top:.5rem;color:var(--brand-danger,#c00);}
+.checkout-notes{margin-top:.5rem;font-size:.9rem;color:#555;}

--- a/assets/js/cart-page.js
+++ b/assets/js/cart-page.js
@@ -11,6 +11,34 @@ $(function () {
   const $empty = $('#empty-state');
   let appliedCoupon = localStorage.getItem('couponCode') || '';
 
+  function getCurrency(){
+    return (window.Checkout && window.Checkout.config && window.Checkout.config.currencyDefault) || 'USD';
+  }
+
+  function cartItems(){
+    const items = [];
+    simpleCart.each(function (item){
+      items.push({
+        id: item.id(),
+        name: item.get('name'),
+        quantity: item.get('quantity'),
+        unit: +item.get('price'),
+        subtotal: +item.total()
+      });
+    });
+    return items;
+  }
+
+  function getTotals(){
+    const subtotal = +simpleCart.total() || 0;
+    const discountObj = computeDiscount(subtotal);
+    const discount = discountObj.amount;
+    const taxBase = Math.max(0, subtotal - discount);
+    const tax = taxBase * TAX_RATE;
+    const grand = Math.max(0, taxBase + tax);
+    return { subtotal, discount, tax, shipping: 0, grandTotal: grand };
+  }
+
   function formatCurrency(n) {
     return '$' + Number(n).toFixed(2);
   }
@@ -26,10 +54,12 @@ $(function () {
       $('.cart-head').addClass('hidden');
       $empty.removeClass('hidden');
       $('#cart-count').text(0);
+      $('#checkout-btn').prop('disabled', true);
       return;
     }
     $('.cart-head').removeClass('hidden');
     $empty.addClass('hidden');
+    $('#checkout-btn').prop('disabled', false);
 
     items.forEach(item => {
       const row = $('<div class="row"></div>').attr('data-id', item.id());
@@ -154,18 +184,26 @@ $(function () {
   }
 
   $('#checkout-btn').on('click', function () {
-    try {
-      simpleCart.checkout();
-    } catch (e) {
-      const items = [];
-      simpleCart.each(function (item) {
-        items.push({ name: item.get('name'), price: item.get('price'), quantity: item.get('quantity') });
-      });
-      if (window.location.pathname !== '/checkout.html') {
-        window.location.href = '/checkout.html';
-      } else {
-        alert('TODO: Configure checkout\n\n' + JSON.stringify(items));
-      }
+    const items = cartItems();
+    if (items.length === 0) return;
+    const totals = getTotals();
+    const order = {
+      id: 'ORD-' + Date.now(),
+      currency: getCurrency(),
+      items: items,
+      amount: totals.grandTotal,
+      subtotal: totals.subtotal,
+      discount: totals.discount,
+      shipping: totals.shipping,
+      tax: totals.tax,
+      coupon: appliedCoupon || null,
+      shippingMethod: null,
+      buyer: null,
+      fx: { base: 'USD', target: 'PKR', rate: (window.Checkout && window.Checkout.config ? window.Checkout.config.pkConversionRate : 0) }
+    };
+    const method = $('input[name="pm"]:checked').val();
+    if (window.Checkout && typeof window.Checkout.start === 'function') {
+      window.Checkout.start(order, method);
     }
   });
 

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -1,0 +1,85 @@
+import { Payments, fmt, toPKR } from './payments.js';
+
+const Checkout = {
+  config: null,
+  async init(){
+    this.config = await fetch('/payments-config.json').then(r=>r.json()).catch(()=>null);
+    this.initTabs();
+    const url = new URL(window.location);
+    if (url.searchParams.get('cancel') === '1'){
+      const fb = document.getElementById('pm-feedback');
+      if (fb) fb.textContent = 'Payment was canceled. You can try another method.';
+    }
+  },
+  initTabs(){
+    const tabs = document.querySelectorAll('.pm-tabs [role="tab"]');
+    const panels = document.querySelectorAll('.pm-section [role="tabpanel"]');
+    function activate(tab){
+      tabs.forEach(t=>{
+        const sel = t===tab;
+        t.setAttribute('aria-selected', sel);
+        const panel = document.getElementById(t.getAttribute('aria-controls'));
+        if(panel) panel.hidden = !sel;
+      });
+    }
+    tabs.forEach(tab=>{
+      tab.addEventListener('click', ()=>activate(tab));
+      tab.addEventListener('keydown', e=>{
+        if(e.key==='ArrowRight' || e.key==='ArrowLeft'){
+          let idx=[...tabs].indexOf(tab);
+          idx = e.key==='ArrowRight'? (idx+1)%tabs.length : (idx-1+tabs.length)%tabs.length;
+          tabs[idx].focus();
+          activate(tabs[idx]);
+        }
+      });
+    });
+    if(tabs[0]) activate(tabs[0]);
+  },
+  async start(order, method){
+    if(!this.config) await this.init();
+    const providerCfg = this.config && this.config.providers[method];
+    const fb = document.getElementById('pm-feedback');
+    if(!providerCfg){
+      if(fb) fb.textContent = 'This method isn\u2019t configured.';
+      return;
+    }
+    const adapter = Payments[method];
+    if(!adapter){
+      if(fb) fb.textContent = 'This method isn\u2019t configured.';
+      return;
+    }
+    const notes = document.getElementById('checkout-notes');
+    let ord = order;
+    if(method !== 'paypal' && order.currency !== 'PKR'){
+      ord = toPKR(order, this.config.pkConversionRate);
+      if(notes) notes.textContent = `Charged in PKR at 1 USD = ${this.config.pkConversionRate} PKR (est.).`;
+    } else if(notes){ notes.textContent = ''; }
+
+    const returnUrls = {
+      successUrl: `${this.config.returnUrls.success}?oid=${encodeURIComponent(ord.id)}&pm=${method}`,
+      cancelUrl: `${this.config.returnUrls.cancel}?cancel=1&pm=${method}`
+    };
+
+    try{
+      const res = await adapter.start(ord, providerCfg, returnUrls);
+      localStorage.setItem('4d-last-order', JSON.stringify(ord));
+      if(res.redirectUrl){
+        window.location = res.redirectUrl;
+      } else if(res.action && res.fields){
+        const f = document.createElement('form');
+        f.method='POST'; f.action = res.action;
+        Object.entries(res.fields).forEach(([k,v])=>{ const i=document.createElement('input'); i.type='hidden'; i.name=k; i.value=v; f.appendChild(i); });
+        document.body.appendChild(f); f.submit();
+      } else if(res.mailto){
+        window.location = res.mailto;
+      }
+    }catch(e){
+      console.error(e);
+      if(fb) fb.textContent = 'Checkout failed. Please try again.';
+    }
+  }
+};
+
+Checkout.init();
+window.Checkout = Checkout;
+export default Checkout;

--- a/assets/js/payments.js
+++ b/assets/js/payments.js
@@ -1,0 +1,158 @@
+export const Payments = {
+  paypal: {
+    needsServer: true,
+    async start(order, cfg, returnUrls){
+      const res = await fetch(cfg.serverless.createUrl, {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ order, returnUrls })
+      });
+      return await res.json();
+      /*
+      // Example serverless handler (Express style)
+      // app.post('/paypal/create-order', async (req,res)=>{
+      //   const { order, returnUrls } = req.body;
+      //   // call PayPal API with secrets
+      //   res.json({ redirectUrl: 'https://paypal.com/checkout?token=...' });
+      // });
+      */
+    }
+  },
+  hblpay: {
+    needsServer: true,
+    async start(order, cfg, returnUrls){
+      const res = await fetch(cfg.serverless.createUrl, {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ order, returnUrls })
+      });
+      return await res.json();
+      /*
+      // Example:
+      // app.post('/hblpay/create-session',(req,res)=>{
+      //   const { order, returnUrls } = req.body;
+      //   // sign request with HBLPay credentials
+      //   res.json({ redirectUrl: 'https://hblpay.com/checkout/...' });
+      // });
+      */
+    }
+  },
+  easypaisa: {
+    needsServer:true,
+    formPost:true,
+    async start(order,cfg, returnUrls){
+      const res = await fetch(cfg.serverless.createUrl,{
+        method:'POST',headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ order, returnUrls })
+      });
+      return await res.json();
+      // Sample serverless:
+      // app.post('/easypaisa/create-session',(req,res)=>{
+      //   const { order, returnUrls } = req.body;
+      //   // compute merchantHashedReq with secret key and return signed fields
+      //   res.json({ action: cfg.endpoint, fields: { /* signed fields */ } });
+      // });
+    }
+  },
+  jazzcash: {
+    needsServer:true,
+    formPost:true,
+    async start(order,cfg, returnUrls){
+      const res = await fetch(cfg.serverless.createUrl,{
+        method:'POST',headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ order, returnUrls })
+      });
+      return await res.json();
+      /*
+      // serverless example for JazzCash signing
+      */
+    }
+  },
+  payfast: {
+    needsServer:true,
+    formPost:true,
+    async start(order,cfg, returnUrls){
+      const res = await fetch(cfg.serverless.createUrl,{
+        method:'POST',headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ order, returnUrls })
+      });
+      return await res.json();
+      /*
+      // serverless example for PayFast signature
+      */
+    }
+  },
+  paypro: {
+    needsServer:true,
+    async start(order,cfg, returnUrls){
+      const res = await fetch(cfg.serverless.createUrl,{
+        method:'POST',headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ order, returnUrls })
+      });
+      return await res.json();
+      /* sample: create invoice and return {redirectUrl} */
+    }
+  },
+  bsecure: {
+    needsServer:true,
+    async start(order,cfg, returnUrls){
+      const res = await fetch(cfg.serverless.createUrl,{
+        method:'POST',headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ order, returnUrls })
+      });
+      return await res.json();
+    }
+  },
+  nift: {
+    needsServer:true,
+    async start(order,cfg, returnUrls){
+      const res = await fetch(cfg.serverless.createUrl,{
+        method:'POST',headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ order, returnUrls })
+      });
+      return await res.json();
+    }
+  },
+  bank: {
+    needsServer:false,
+    async start(order, cfg){
+      const body = `\nORDER REQUEST (Bank Transfer)\nOrder: ${order.id}\nAmount: ${fmt(order.amount, order.currency)}\nItems:\n${order.items.map(i=>`• ${i.name} × ${i.qty} = ${fmt(i.subtotal, order.currency)}`).join('\n')}\n---\nBank details:\n${cfg.account.title}\n${cfg.account.bank} – ${cfg.account.branch}\nIBAN: ${cfg.account.iban}\nAccount#: ${cfg.account.accountNo}\n\nReply with transfer receipt to complete your order.`;
+      const mailto = `mailto:${cfg.mailto}?subject=${encodeURIComponent('Bank Transfer - '+order.id)}&body=${encodeURIComponent(body)}`;
+      return { mailto };
+    }
+  },
+  cod: {
+    needsServer:false,
+    async start(order, cfg){
+      const body = `\nCOD REQUEST\nOrder: ${order.id}\nAmount to collect on delivery: ${fmt(order.amount, order.currency)}\nBuyer: ${safeBuyer(order.buyer)}\nItems:\n${order.items.map(i=>`• ${i.name} × ${i.qty}`).join('\n')}\nAddress: ${order.buyer?.address || '—'}\nPhone: ${order.buyer?.phone || '—'}\n`;
+      const mailto = `mailto:${cfg.mailto}?subject=${encodeURIComponent('COD - '+order.id)}&body=${encodeURIComponent(body)}`;
+      return { mailto };
+    }
+  }
+};
+
+export function fmt(n, ccy){
+  return new Intl.NumberFormat('en-US', {style:'currency', currency: ccy}).format(n);
+}
+
+function safeBuyer(b){
+  if(!b) return '—';
+  const parts = [];
+  if(b.name) parts.push(b.name);
+  if(b.email) parts.push(b.email);
+  return parts.join(' / ') || '—';
+}
+
+export function toPKR(order, rate){
+  const cloned = JSON.parse(JSON.stringify(order));
+  cloned.fx = { base: order.currency, target: 'PKR', rate: rate, baseAmount: order.amount };
+  const convert = (n)=> Math.round(n * rate * 100)/100;
+  cloned.currency = 'PKR';
+  cloned.amount = convert(order.amount);
+  cloned.subtotal = convert(order.subtotal);
+  cloned.discount = convert(order.discount);
+  cloned.shipping = convert(order.shipping);
+  cloned.tax = convert(order.tax);
+  cloned.items = order.items.map(i=>({ ...i, unit: convert(i.unit), subtotal: convert(i.subtotal) }));
+  return cloned;
+}

--- a/cart.html
+++ b/cart.html
@@ -6,6 +6,7 @@
   <title>Your Cart • 4D Cosmetics</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Playfair+Display:wght@600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/css/cart.css">
+  <link rel="stylesheet" href="/assets/css/checkout.css">
 </head>
 <body>
   <header class="site-header">
@@ -78,7 +79,47 @@
           </div>
         </div>
 
+        <section id="payment-methods" aria-labelledby="pm-title" class="pm-section">
+          <h2 id="pm-title">Payment method</h2>
+
+          <!-- Tabs -->
+          <div class="pm-tabs" role="tablist" aria-label="Checkout methods">
+            <button role="tab" aria-selected="true" id="tab-international" aria-controls="panel-international">International</button>
+            <button role="tab" aria-selected="false" id="tab-pakistan" aria-controls="panel-pakistan">Pakistan</button>
+            <button role="tab" aria-selected="false" id="tab-offline" aria-controls="panel-offline">Offline</button>
+          </div>
+
+          <!-- International panel -->
+          <div role="tabpanel" id="panel-international" aria-labelledby="tab-international">
+            <label class="pm-option">
+              <input type="radio" name="pm" value="paypal" checked>
+              <span>PayPal</span>
+            </label>
+          </div>
+
+          <!-- Pakistan panel -->
+          <div role="tabpanel" id="panel-pakistan" aria-labelledby="tab-pakistan" hidden>
+            <label class="pm-option"><input type="radio" name="pm" value="hblpay"> HBLPay (Visa / Master / Debit)</label>
+            <label class="pm-option"><input type="radio" name="pm" value="easypaisa"> Easypaisa (Hosted)</label>
+            <label class="pm-option"><input type="radio" name="pm" value="jazzcash"> JazzCash (Hosted)</label>
+            <label class="pm-option"><input type="radio" name="pm" value="payfast"> PayFast (Aggregator)</label>
+            <label class="pm-option"><input type="radio" name="pm" value="paypro"> PayPro (Aggregator)</label>
+            <label class="pm-option"><input type="radio" name="pm" value="bsecure"> bSecure (Aggregator)</label>
+            <label class="pm-option"><input type="radio" name="pm" value="nift"> NIFT ePay</label>
+            <small class="pm-note">Local gateways charge in PKR. A conversion line will be shown if your cart is in USD.</small>
+          </div>
+
+          <!-- Offline panel -->
+          <div role="tabpanel" id="panel-offline" aria-labelledby="tab-offline" hidden>
+            <label class="pm-option"><input type="radio" name="pm" value="bank"> Bank Transfer</label>
+            <label class="pm-option"><input type="radio" name="pm" value="cod"> Cash on Delivery</label>
+          </div>
+
+          <div id="pm-feedback" class="pm-feedback" role="status" aria-live="polite"></div>
+        </section>
+
         <button id="checkout-btn" class="btn btn-primary btn-lg w-100">Check out</button>
+        <div id="checkout-notes" class="checkout-notes" aria-live="polite"></div>
       </div>
     </aside>
   </main>
@@ -93,10 +134,12 @@
     </div>
   </footer>
 
+  <div id="checkout-return" data-checkout-return></div>
   <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
   <script src="/assets/js/simpleCart.min.js"></script>   <!-- must be before our page script -->
   <script src="/assets/js/simpleStore.js"></script>
   <script src="/assets/js/config.js"></script>
   <script src="/assets/js/cart-page.js"></script>
+  <script type="module" src="/assets/js/checkout.js"></script>
 </body>
 </html>

--- a/payments-config.json
+++ b/payments-config.json
@@ -1,0 +1,90 @@
+{
+  "currencyDefault": "USD",
+  "pkConversionRate": 278.00,
+  "sandbox": true,
+  "returnUrls": {
+    "success": "/thank-you.html",
+    "cancel": "/cart.html"
+  },
+  "providers": {
+    "paypal": {
+      "type": "hosted",
+      "mode": "redirect",
+      "serverless": {
+        "createUrl": "https://YOUR_FUNCTION_DOMAIN/paypal/create-order"
+      }
+    },
+    "hblpay": {
+      "type": "hosted",
+      "mode": "server-init",
+      "serverless": {
+        "createUrl": "https://YOUR_FUNCTION_DOMAIN/hblpay/create-session"
+      }
+    },
+    "easypaisa": {
+      "type": "hosted",
+      "mode": "form-post",
+      "endpoint": "https://easypay.easypaisa.com.pk/easypay/Index.jsf",
+      "fields": ["storeId","orderRefNum","amount","postBackURL","expiryDateTime","merchantHashedReq"],
+      "serverless": {
+        "createUrl": "https://YOUR_FUNCTION_DOMAIN/easypaisa/create-session"
+      }
+    },
+    "jazzcash": {
+      "type": "hosted",
+      "mode": "form-post",
+      "endpoint": "https://payments.jazzcash.com/CustomerPortal/transactionmanagement/merchantform/",
+      "fields": ["pp_Version","pp_TxnType","pp_Language","pp_MerchantID","pp_Password","pp_TxnRefNo","pp_Amount","pp_TxnCurrency","pp_BillReference","pp_Description","pp_ReturnURL","pp_SecureHash"],
+      "serverless": {
+        "createUrl": "https://YOUR_FUNCTION_DOMAIN/jazzcash/create-session"
+      }
+    },
+    "payfast": {
+      "type": "aggregator",
+      "mode": "form-post",
+      "endpoint": "https://ipg1.payfast.pk/customer/initialize",
+      "fields": ["merchant_id","merchant_password","return_url","cancel_url","currency","amount","order_id","description","signature"],
+      "serverless": {
+        "createUrl": "https://YOUR_FUNCTION_DOMAIN/payfast/create-order"
+      }
+    },
+    "paypro": {
+      "type": "aggregator",
+      "mode": "server-init",
+      "serverless": {
+        "createUrl": "https://YOUR_FUNCTION_DOMAIN/paypro/create-invoice"
+      }
+    },
+    "bsecure": {
+      "type": "aggregator",
+      "mode": "server-init",
+      "serverless": {
+        "createUrl": "https://YOUR_FUNCTION_DOMAIN/bsecure/create-checkout"
+      }
+    },
+    "nift": {
+      "type": "hosted",
+      "mode": "server-init",
+      "serverless": {
+        "createUrl": "https://YOUR_FUNCTION_DOMAIN/nift/create-session"
+      }
+    },
+    "bank": {
+      "type": "offline",
+      "mode": "mailto",
+      "account": {
+        "title": "4D Cosmetics",
+        "bank": "HBL",
+        "iban": "PK00HABB0000000000000000",
+        "accountNo": "00000000000000",
+        "branch": "Gulberg, Lahore"
+      },
+      "mailto": "orders@4dcosmetics.com"
+    },
+    "cod": {
+      "type": "offline",
+      "mode": "mailto",
+      "mailto": "orders@4dcosmetics.com"
+    }
+  }
+}

--- a/thank-you.html
+++ b/thank-you.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>Thank You • 4D Cosmetics</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Playfair+Display:wght@600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/assets/css/cart.css">
+  <link rel="stylesheet" href="/assets/css/checkout.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <a class="brand" href="/"> <span class="brand-mark">4D</span> Cosmetics</a>
+      <nav class="nav">
+        <a href="/products.html">Products</a>
+        <a href="/about.html">About</a>
+        <a href="/contact.html">Contact</a>
+        <a href="/cart.html">Cart</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container thankyou-layout">
+    <h1>Thank you</h1>
+    <div id="order-receipt"></div>
+    <a href="/products.html" class="btn btn-primary mt-3">Continue shopping</a>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <small>© 4D Cosmetics</small>
+      <nav>
+        <a href="/privacy.html">Privacy</a>
+        <a href="/terms.html">Terms</a>
+      </nav>
+    </div>
+  </footer>
+
+  <script type="module">
+    import { fmt } from '/assets/js/payments.js';
+    const data = localStorage.getItem('4d-last-order');
+    const receipt = document.getElementById('order-receipt');
+    const url = new URL(window.location);
+    if(data){
+      const order = JSON.parse(data);
+      const pm = url.searchParams.get('pm') || '—';
+      const txn = url.searchParams.get('txn');
+      let html = `<p><strong>Order ID:</strong> ${order.id}</p>`;
+      if(txn) html += `<p><strong>Reference:</strong> ${txn}</p>`;
+      html += `<p><strong>Payment method:</strong> ${pm}</p>`;
+      html += '<ul>' + order.items.map(i=>`<li>${i.name} × ${i.quantity} = ${fmt(i.subtotal, order.currency)}</li>`).join('') + '</ul>';
+      html += `<p><strong>Total:</strong> ${fmt(order.amount, order.currency)}</p>`;
+      if(order.fx && order.fx.base !== order.currency){
+        html += `<p class="small">Base amount: ${fmt(order.fx.baseAmount, order.fx.base)} (1 USD = ${order.fx.rate} PKR)</p>`;
+      }
+      receipt.innerHTML = html;
+    } else {
+      receipt.innerHTML = '<p>Thank you for your purchase.</p>';
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce payment method chooser with international, Pakistani, and offline options
- wire cart checkout to new provider adapters and config
- add thank-you receipt page and styling
- fix payments adapter comment syntax and item quantity fields

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689faaf332588320b938009d6916e541