### PR TITLE
Improve cart layout and responsiveness

### DIFF
--- a/assets/css/cart.css
+++ b/assets/css/cart.css
@@ -22,17 +22,18 @@ h1{font-family:"Playfair Display",serif;margin:24px 0 16px;font-size:28px}
 .nav a{color:var(--brand-text);text-decoration:none;margin-left:16px;opacity:.85}
 .nav a.active,.nav a:hover{opacity:1}
 
-.cart-layout{display:grid;grid-template-columns:2fr 1fr;gap:24px}
+.cart-layout{display:grid;gap:24px}
 .cart-items{background:#fff;border:1px solid var(--border);border-radius:12px;overflow:hidden}
-.cart-head{display:grid;grid-template-columns:1fr 120px 160px 120px 24px;gap:12px;padding:12px 16px;border-bottom:1px solid var(--border);font-weight:600;color:#000}
+.cart-head{display:grid;grid-template-columns:minmax(0,1fr) 120px 160px 120px 24px;gap:12px;padding:12px 16px;border-bottom:1px solid var(--border);font-weight:600;color:#000}
 .cart-rows{display:block}
-.row{display:grid;grid-template-columns:1fr 120px 160px 120px 24px;gap:12px;align-items:center;padding:16px;border-bottom:1px solid var(--border)}
+.row{display:grid;grid-template-columns:minmax(0,1fr) 120px 160px 120px 24px;gap:12px;align-items:center;padding:16px;border-bottom:1px solid var(--border)}
 .row:last-child{border-bottom:0}
-.item{display:flex;gap:12px;align-items:center}
+.item{display:flex;gap:12px;align-items:flex-start}
 .thumb{width:64px;height:64px;border-radius:8px;object-fit:cover;border:1px solid var(--border);background:#fff}
-.title{font-weight:600}
-.meta{color:var(--muted);font-size:12px;margin-top:2px}
-.price,.line-total{font-weight:600}
+.info{min-width:0}
+.title{font-weight:600;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2}
+.meta{color:var(--muted);font-size:12px;margin-top:2px;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2}
+.price,.line-total{font-weight:600;white-space:nowrap}
 .hide-sm{display:block}
 
 .qty{display:inline-flex;align-items:center;border:1px solid var(--border);border-radius:10px;overflow:hidden}
@@ -66,15 +67,19 @@ h1{font-family:"Playfair Display",serif;margin:24px 0 16px;font-size:28px}
 
 .empty{padding:24px;text-align:center}
 
+@media (min-width:992px){
+  .cart-layout{grid-template-columns:2fr 1fr;align-items:flex-start}
+  .cart-items{max-height:70vh;overflow-y:auto}
+}
+
 @media (max-width:991px){
-  .cart-layout{grid-template-columns:1fr}
-  .cart-head{grid-template-columns:1fr 100px 140px 100px 24px}
-  .row{grid-template-columns:1fr 100px 140px 100px 24px}
+  .cart-head{grid-template-columns:minmax(0,1fr) 100px 140px 100px 24px}
+  .row{grid-template-columns:minmax(0,1fr) 100px 140px 100px 24px}
   .hide-sm{display:none}
 }
 @media (max-width:575px){
   .cart-head{display:none}
-  .row{grid-template-columns:1fr 80px 120px 80px 24px;padding:12px}
+  .row{grid-template-columns:minmax(0,1fr) 80px 120px 80px 24px;padding:12px}
   .thumb{width:48px;height:48px}
   .qty button{padding:6px 8px}
   .qty input{width:32px}

--- a/cart.html
+++ b/cart.html
@@ -21,10 +21,11 @@
     </div>
   </header>
 
-  <main class="container cart-layout">
+  <main class="container">
     <h1>Your Cart (<span id="cart-count">0</span> items)</h1>
 
-    <section class="cart-items">
+    <div class="cart-layout">
+      <section class="cart-items">
       <div class="cart-head row">
         <div>Item</div>
         <div class="hide-sm">Price</div>
@@ -40,9 +41,9 @@
         <p>Your cart is empty.</p>
         <a class="btn btn-primary" href="/products.html">Continue shopping</a>
       </div>
-    </section>
+      </section>
 
-    <aside class="cart-summary">
+      <aside class="cart-summary">
       <div class="card">
         <div class="summary-line">
           <span>Subtotal:</span>
@@ -121,7 +122,8 @@
         <button id="checkout-btn" class="btn btn-primary btn-lg w-100">Check out</button>
         <div id="checkout-notes" class="checkout-notes" aria-live="polite"></div>
       </div>
-    </aside>
+      </aside>
+    </div>
   </main>
 
   <footer class="site-footer">


### PR DESCRIPTION
## Summary
- Restructure cart layout to use a dedicated grid wrapper so items and summary align correctly
- Add responsive styles: clamp overflowing item text, maintain fixed image sizes, and scrollable item list with sticky summary

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689fb17584908320a6077210a0076813