### PR TITLE
Remove PayPal and consolidate checkout payment options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,7 @@ or manually install using the latest [release](https://github.com/chrisdiana/sim
 
 1.Make sure simpleStore is on a web server (any type will do as long as it can serve static web pages).
 
-2.Configure your payment options in `js/config.js`.
-
-```
-checkout: {
-	type: "PayPal" ,
-	email: "you@yours.com"
-},
-```
+2.Configure your payment options in `payments-config.json`.
 
 3.Edit the `js/config.js` to your liking.
 

--- a/assets/css/checkout.css
+++ b/assets/css/checkout.css
@@ -1,7 +1,3 @@
-.pm-tabs{display:flex;gap:.5rem;margin:.5rem 0;}
-.pm-tabs button{padding:.4rem .75rem;border:1px solid #ccc;background:#f8f8f8;cursor:pointer;}
-.pm-tabs button[aria-selected="true"]{background:#fff;border-bottom:2px solid var(--brand-primary,#333);}
-.pm-tabs button:focus{outline:2px solid var(--brand-primary,#333);outline-offset:2px;}
 .pm-option{display:block;margin:.25rem 0;}
 .pm-feedback{margin-top:.5rem;color:var(--brand-danger,#c00);}
 .checkout-notes{margin-top:.5rem;font-size:.9rem;color:#555;}

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -4,36 +4,11 @@ const Checkout = {
   config: null,
   async init(){
     this.config = await fetch('/payments-config.json').then(r=>r.json()).catch(()=>null);
-    this.initTabs();
     const url = new URL(window.location);
     if (url.searchParams.get('cancel') === '1'){
       const fb = document.getElementById('pm-feedback');
       if (fb) fb.textContent = 'Payment was canceled. You can try another method.';
     }
-  },
-  initTabs(){
-    const tabs = document.querySelectorAll('.pm-tabs [role="tab"]');
-    const panels = document.querySelectorAll('.pm-section [role="tabpanel"]');
-    function activate(tab){
-      tabs.forEach(t=>{
-        const sel = t===tab;
-        t.setAttribute('aria-selected', sel);
-        const panel = document.getElementById(t.getAttribute('aria-controls'));
-        if(panel) panel.hidden = !sel;
-      });
-    }
-    tabs.forEach(tab=>{
-      tab.addEventListener('click', ()=>activate(tab));
-      tab.addEventListener('keydown', e=>{
-        if(e.key==='ArrowRight' || e.key==='ArrowLeft'){
-          let idx=[...tabs].indexOf(tab);
-          idx = e.key==='ArrowRight'? (idx+1)%tabs.length : (idx-1+tabs.length)%tabs.length;
-          tabs[idx].focus();
-          activate(tabs[idx]);
-        }
-      });
-    });
-    if(tabs[0]) activate(tabs[0]);
   },
   async start(order, method){
     if(!this.config) await this.init();
@@ -50,7 +25,7 @@ const Checkout = {
     }
     const notes = document.getElementById('checkout-notes');
     let ord = order;
-    if(method !== 'paypal' && order.currency !== 'PKR'){
+    if(order.currency !== 'PKR'){
       ord = toPKR(order, this.config.pkConversionRate);
       if(notes) notes.textContent = `Charged in PKR at 1 USD = ${this.config.pkConversionRate} PKR (est.).`;
     } else if(notes){ notes.textContent = ''; }

--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -11,10 +11,6 @@ $(function() {
       { view: "remove", text: "Remove", label: false }
     ],
     cartStyle: "div",
-    checkout: {
-      type: "PayPal",
-      email: "you@yours.com"
-    },
     currency: "USD"
   });
 

--- a/assets/js/payments.js
+++ b/assets/js/payments.js
@@ -1,23 +1,4 @@
 export const Payments = {
-  paypal: {
-    needsServer: true,
-    async start(order, cfg, returnUrls){
-      const res = await fetch(cfg.serverless.createUrl, {
-        method:'POST',
-        headers:{'Content-Type':'application/json'},
-        body: JSON.stringify({ order, returnUrls })
-      });
-      return await res.json();
-      /*
-      // Example serverless handler (Express style)
-      // app.post('/paypal/create-order', async (req,res)=>{
-      //   const { order, returnUrls } = req.body;
-      //   // call PayPal API with secrets
-      //   res.json({ redirectUrl: 'https://paypal.com/checkout?token=...' });
-      // });
-      */
-    }
-  },
   hblpay: {
     needsServer: true,
     async start(order, cfg, returnUrls){

--- a/cart.html
+++ b/cart.html
@@ -92,37 +92,17 @@
         <section id="payment-methods" aria-labelledby="pm-title" class="pm-section">
           <h2 id="pm-title">Payment method</h2>
 
-          <!-- Tabs -->
-          <div class="pm-tabs" role="tablist" aria-label="Checkout methods">
-            <button role="tab" aria-selected="true" id="tab-international" aria-controls="panel-international">International</button>
-            <button role="tab" aria-selected="false" id="tab-pakistan" aria-controls="panel-pakistan">Pakistan</button>
-            <button role="tab" aria-selected="false" id="tab-offline" aria-controls="panel-offline">Offline</button>
-          </div>
-
-          <!-- International panel -->
-          <div role="tabpanel" id="panel-international" aria-labelledby="tab-international">
-            <label class="pm-option">
-              <input type="radio" name="pm" value="paypal" checked>
-              <span>PayPal</span>
-            </label>
-          </div>
-
-          <!-- Pakistan panel -->
-          <div role="tabpanel" id="panel-pakistan" aria-labelledby="tab-pakistan" hidden>
-            <label class="pm-option"><input type="radio" name="pm" value="hblpay"> HBLPay (Visa / Master / Debit)</label>
+          <div class="pm-options" role="radiogroup" aria-label="Payment methods">
+            <label class="pm-option"><input type="radio" name="pm" value="hblpay" checked> HBLPay (Visa / Master / Debit)</label>
             <label class="pm-option"><input type="radio" name="pm" value="easypaisa"> Easypaisa (Hosted)</label>
             <label class="pm-option"><input type="radio" name="pm" value="jazzcash"> JazzCash (Hosted)</label>
             <label class="pm-option"><input type="radio" name="pm" value="payfast"> PayFast (Aggregator)</label>
             <label class="pm-option"><input type="radio" name="pm" value="paypro"> PayPro (Aggregator)</label>
             <label class="pm-option"><input type="radio" name="pm" value="bsecure"> bSecure (Aggregator)</label>
             <label class="pm-option"><input type="radio" name="pm" value="nift"> NIFT ePay</label>
-            <small class="pm-note">Local gateways charge in PKR. A conversion line will be shown if your cart is in USD.</small>
-          </div>
-
-          <!-- Offline panel -->
-          <div role="tabpanel" id="panel-offline" aria-labelledby="tab-offline" hidden>
             <label class="pm-option"><input type="radio" name="pm" value="bank"> Bank Transfer</label>
             <label class="pm-option"><input type="radio" name="pm" value="cod"> Cash on Delivery</label>
+            <small class="pm-note">Local gateways charge in PKR. A conversion line will be shown if your cart is in USD.</small>
           </div>
 
           <div id="pm-feedback" class="pm-feedback" role="status" aria-live="polite"></div>

--- a/payments-config.json
+++ b/payments-config.json
@@ -7,13 +7,6 @@
     "cancel": "/cart.html"
   },
   "providers": {
-    "paypal": {
-      "type": "hosted",
-      "mode": "redirect",
-      "serverless": {
-        "createUrl": "https://YOUR_FUNCTION_DOMAIN/paypal/create-order"
-      }
-    },
     "hblpay": {
       "type": "hosted",
       "mode": "server-init",


### PR DESCRIPTION
## Summary
- Replace tabbed checkout with a single list of payment methods, combining Pakistan and offline options while dropping PayPal/international choices.
- Simplify checkout logic by removing tab code and always converting non-PKR orders to PKR.
- Clean up payment configuration and adapters to remove the PayPal provider.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689fb91afb048320b4b1dae7afd33755