### PR TITLE
Fix simpleCart PKR currency initialization

### DIFF
--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -1,3 +1,10 @@
+// Register Pakistani Rupee currency before configuring simpleCart
+simpleCart.currency({
+  code: 'PKR',
+  name: 'Pakistani Rupee',
+  symbol: 'Rs.'
+});
+
 $(function() {
   // Initialize simpleCart
   simpleCart({


### PR DESCRIPTION
## Summary
- Register Pakistani Rupee currency with simpleCart
- Initialize cart using newly registered currency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689fc23012bc8320b459c56748ad0573