### PR TITLE
fix: align cart navbar with site

### DIFF
--- a/assets/css/cart.css
+++ b/assets/css/cart.css
@@ -12,7 +12,7 @@
 *{box-sizing:border-box}
 html,body{margin:0;padding:0;color:var(--brand-text);font-family:Inter,system-ui,Arial,sans-serif;background:var(--brand-bg)}
 h1{font-family:"Playfair Display",serif;margin:24px 0 16px;font-size:28px}
-.container{width:100%;max-width:1120px;margin:0 auto;padding:0 16px}
+main.container{width:100%;max-width:1120px;margin:0 auto;padding:0 16px}
 
 .site-header,.site-footer{background:#fff;border-bottom:1px solid var(--border)}
 .site-footer{border-top:1px solid var(--border);border-bottom:0;margin-top:48px}


### PR DESCRIPTION
## Summary
- scope cart container styles to main element to match global navbar

## Testing
- `npx --yes htmlhint index.html about.html contact.html cart.html terms.html privacy.html thank-you.html products.html`
- `npm test` *(fails: no test specified)*
- `npx --yes lighthouse http://localhost:8080/index.html --output=json --output-path=./lighthouse-report.json --quiet --chrome-flags="--headless"` *(fails: Chromium not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689fcdac7dfc832084f756eaf0e1368f