### PR TITLE
feat: animate cart count on add

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -42,3 +42,16 @@ footer a:hover { text-decoration: underline; }
 .card .item_price {
   font-weight: bold;
 }
+
+.simpleCart_quantity {
+  display: inline-block;
+}
+
+.cart-bounce {
+  animation: cart-bounce 0.4s ease;
+}
+
+@keyframes cart-bounce {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.3); }
+}

--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -56,4 +56,13 @@ $(function() {
     });
     $('#order').val(JSON.stringify(items));
   });
+
+  // Animate cart count when items are added
+  simpleCart.bind('afterAdd', function() {
+    var $qty = $('.simpleCart_quantity');
+    $qty.addClass('cart-bounce');
+    setTimeout(function() {
+      $qty.removeClass('cart-bounce');
+    }, 400);
+  });
 });


### PR DESCRIPTION
## Summary
- bounce cart quantity after adding items to indicate success

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689fe5240c2c832092e5aebf2bf3e438