### PR TITLE
Prevent overflow for control button groups

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -55,3 +55,12 @@ footer a:hover { text-decoration: underline; }
   0%, 100% { transform: scale(1); }
   50% { transform: scale(1.3); }
 }
+
+/* Prevent button groups from overflowing on small screens */
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+}
+


### PR DESCRIPTION
## Summary
- allow `.controls` sections to wrap their buttons onto new lines
- keep icon groups centered so extra buttons move to the next row on narrow screens

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a38e2d12e883208b5dfc05852e0d48