### PR TITLE
Mute media playback on homepage

### DIFF
--- a/assets/js/mute-media.js
+++ b/assets/js/mute-media.js
@@ -1,0 +1,4 @@
+$(function() {
+  // Mute all video and audio elements on the page by default
+  $('video, audio').prop('muted', true);
+});

--- a/index.html
+++ b/index.html
@@ -61,5 +61,6 @@
   <script src="./assets/js/simpleCart.min.js"></script>
   <script src="./assets/js/simpleStore.js"></script>
   <script src="./assets/js/config.js"></script>
+  <script src="./assets/js/mute-media.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure any audio or video on `index.html` starts muted

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a38e5acccc8320b2b65c7777d5c3ee