### PR TITLE
Ensure video sections maintain minimum height

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -64,3 +64,9 @@ footer a:hover { text-decoration: underline; }
   gap: 0.5rem;
 }
 
+/* Prevent media overflow by enforcing minimum height */
+#playerFrame,
+.live-player,
+.youtube-section.media-hub-section {
+  min-height: 315px;
+}


### PR DESCRIPTION
## Summary
- prevent player overflow by giving `#playerFrame`, `.live-player`, and `.youtube-section.media-hub-section` a shared minimum height

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a391c98c108320a3af67241ac01e96