### PR TITLE
Add SPA fallback and SEO/a11y polish for category and product pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Page Not Found | 4D Cosmetics</title>
+  <script>
+    const path = window.location.pathname;
+    if (path.startsWith('/c/') || path.startsWith('/p/')) {
+      const shell = path.startsWith('/c/') ? '/c/' : '/p/';
+      fetch(shell)
+        .then(r => r.ok ? r.text() : Promise.reject())
+        .then(html => {
+          document.open();
+          document.write(html);
+          document.close();
+        })
+        .catch(() => {});
+    }
+  </script>
+</head>
+<body>
+  <h1>Page not found</h1>
+  <p><a href="/">Home</a></p>
+</body>
+</html>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -55,3 +55,11 @@ footer a:hover { text-decoration: underline; }
   0%, 100% { transform: scale(1); }
   50% { transform: scale(1.3); }
 }
+
+.pagination .page-link {
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/assets/js/category-page.js
+++ b/assets/js/category-page.js
@@ -10,14 +10,34 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (!category) {
       return render404();
     }
-    document.title = `${category.name} | 4D Cosmetics`;
-    document.getElementById('canonical-link').setAttribute('href', `/c/${category.slug}/`);
-    const meta = document.querySelector('meta[name="description"]');
-    if (meta && category.descriptionHTML) {
-      const tmp = document.createElement('div');
-      tmp.innerHTML = category.descriptionHTML;
-      meta.setAttribute('content', tmp.textContent.trim().slice(0,160));
-    }
+      const canonicalUrl = `${window.location.origin}/c/${category.slug}/`;
+      document.title = `${category.name} | 4D Cosmetics`;
+      document.getElementById('canonical-link').setAttribute('href', canonicalUrl);
+      const meta = document.querySelector('meta[name="description"]');
+      let metaDesc = '';
+      if (meta && category.descriptionHTML) {
+        const tmp = document.createElement('div');
+        tmp.innerHTML = category.descriptionHTML;
+        metaDesc = tmp.textContent.trim().slice(0,160);
+        meta.setAttribute('content', metaDesc);
+      }
+      document.getElementById('og-title').setAttribute('content', `${category.name} | 4D Cosmetics`);
+      if (metaDesc) document.getElementById('og-description').setAttribute('content', metaDesc); else document.getElementById('og-description').remove();
+      document.getElementById('og-url').setAttribute('content', canonicalUrl);
+      if (category.image) {
+        document.getElementById('og-image').setAttribute('content', category.image);
+      } else {
+        document.getElementById('og-image').remove();
+      }
+      const ld = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {"@type": "ListItem", "position": 1, "name": "Home", "item": `${window.location.origin}/`},
+          {"@type": "ListItem", "position": 2, "name": category.name, "item": canonicalUrl}
+        ]
+      };
+      document.getElementById('ld-json').textContent = JSON.stringify(ld);
     document.getElementById('category-title').textContent = category.name;
     if (category.descriptionHTML) {
       document.getElementById('category-description').innerHTML = category.descriptionHTML;
@@ -34,9 +54,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     topCats.forEach(c => {
       const li = document.createElement('li');
       const a = document.createElement('a');
-      a.href = `/c/${c.slug}/`;
-      a.textContent = c.name;
-      if (c.slug === category.slug) a.classList.add('fw-bold');
+        a.href = `/c/${c.slug}/`;
+        a.textContent = c.name;
+        if (c.slug === category.slug) {
+          a.classList.add('fw-bold');
+          a.setAttribute('aria-current', 'page');
+        }
       li.appendChild(a);
       ul.appendChild(li);
     });
@@ -58,7 +81,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     pageItems.forEach(prod => {
       const col = document.createElement('div');
       col.className = 'col-6 col-md-4 col-lg-3 mb-4';
-      col.innerHTML = `<a href="/p/${prod.slug}" class="text-decoration-none text-dark"><div class="card h-100"><img src="${prod.images[0]}" class="card-img-top" alt="${prod.name}"><div class="card-body p-2"><h6 class="card-title">${prod.name}</h6><p class="card-text mb-1">${StorefrontRuntime.formatPrice(prod.price, prod.currency)}</p>${prod.inStock ? '' : '<span class="badge bg-secondary">Out of stock</span>'}</div></div></a>`;
+        col.innerHTML = `<a href="/p/${prod.slug}" class="text-decoration-none text-dark"><div class="card h-100"><img src="${prod.images[0]}" class="card-img-top" alt="${prod.name}" loading="lazy" style="object-fit:cover;aspect-ratio:1/1;"><div class="card-body p-2"><h6 class="card-title">${prod.name}</h6><p class="card-text mb-1">${StorefrontRuntime.formatPrice(prod.price, prod.currency)}</p>${prod.inStock ? '' : '<span class="badge bg-secondary">Out of stock</span>'}</div></div></a>`;
       grid.appendChild(col);
     });
     const totalPages = Math.ceil(products.length / perPage);
@@ -66,14 +89,20 @@ document.addEventListener('DOMContentLoaded', async () => {
       const nav = document.getElementById('pagination');
       const ulp = document.createElement('ul');
       ulp.className = 'pagination';
-      const prev = document.createElement('li');
-      prev.className = 'page-item' + (pageNum === 1 ? ' disabled' : '');
-      const prevA = document.createElement('a');
-      prevA.className = 'page-link';
-      prevA.textContent = 'Previous';
-      if (pageNum > 1) prevA.href = `?page=${pageNum - 1}`;
-      prev.appendChild(prevA);
-      ulp.appendChild(prev);
+        const prev = document.createElement('li');
+        const prevA = document.createElement('a');
+        prevA.className = 'page-link';
+        prevA.textContent = 'Previous';
+        if (pageNum === 1) {
+          prev.className = 'page-item disabled';
+          prevA.setAttribute('aria-disabled', 'true');
+          prevA.tabIndex = -1;
+        } else {
+          prev.className = 'page-item';
+          prevA.href = `?page=${pageNum - 1}`;
+        }
+        prev.appendChild(prevA);
+        ulp.appendChild(prev);
       for (let i = 1; i <= totalPages; i++) {
         const li = document.createElement('li');
         li.className = 'page-item' + (i === pageNum ? ' active' : '');
@@ -84,16 +113,25 @@ document.addEventListener('DOMContentLoaded', async () => {
         li.appendChild(a);
         ulp.appendChild(li);
       }
-      const next = document.createElement('li');
-      next.className = 'page-item' + (pageNum === totalPages ? ' disabled' : '');
-      const nextA = document.createElement('a');
-      nextA.className = 'page-link';
-      nextA.textContent = 'Next';
-      if (pageNum < totalPages) nextA.href = `?page=${pageNum + 1}`;
-      next.appendChild(nextA);
-      ulp.appendChild(next);
-      nav.appendChild(ulp);
-    }
+        const next = document.createElement('li');
+        const nextA = document.createElement('a');
+        nextA.className = 'page-link';
+        nextA.textContent = 'Next';
+        if (pageNum === totalPages) {
+          next.className = 'page-item disabled';
+          nextA.setAttribute('aria-disabled', 'true');
+          nextA.tabIndex = -1;
+        } else {
+          next.className = 'page-item';
+          nextA.href = `?page=${pageNum + 1}`;
+        }
+        next.appendChild(nextA);
+        ulp.appendChild(next);
+        nav.appendChild(ulp);
+        const activeLink = nav.querySelector('.active .page-link');
+        if (activeLink) activeLink.focus();
+      }
+      document.getElementById('product-grid').scrollIntoView();
   } catch (e) {
     console.error(e);
     const container = document.querySelector('.container');

--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -39,10 +39,15 @@ $(function() {
     var row = $('<div class="row"></div>');
     products.forEach(function(p){
       var card = $('<div class="col-md-4 col-sm-6 mb-4">\n        <div class="card h-100 simpleCart_shelfItem">\n          <img class="card-img-top item_thumb" alt="">\n          <div class="card-body d-flex flex-column">\n            <h5 class="card-title item_name"></h5>\n            <p class="item_price text-primary"></p>\n            <p class="card-text item_description"></p>\n            <a class="btn btn-primary mt-auto item_add" href="javascript:;">Add to Cart</a>\n          </div>\n        </div>\n      </div>');
-      card.find('.item_name').text(p.name);
-      card.find('.item_price').text(new Intl.NumberFormat('en', {style: 'currency', currency: p.currency}).format(p.price));
-      card.find('.item_description').text(p.shortDescription);
-      card.find('.item_thumb').attr('src', p.images[0]).attr('alt', p.name);
+        card.find('.item_name').text(p.name);
+        card.find('.item_price').text(new Intl.NumberFormat('en', {style: 'currency', currency: p.currency}).format(p.price));
+        card.find('.item_description').text(p.shortDescription);
+        card.find('.item_thumb')
+          .attr('src', p.images[0])
+          .attr('alt', p.name)
+          .attr('loading', 'lazy')
+          .css('object-fit','cover')
+          .css('aspect-ratio','1/1');
       row.append(card);
     });
     container.html(row);

--- a/assets/js/header-nav.js
+++ b/assets/js/header-nav.js
@@ -8,16 +8,37 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (navList) {
       const li = document.createElement('li');
       li.className = 'nav-item dropdown';
-      li.innerHTML = `<a class="nav-link dropdown-toggle" href="#" id="shopDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Shop</a><ul class="dropdown-menu" aria-labelledby="shopDropdown"></ul>`;
-      const menu = li.querySelector('.dropdown-menu');
-      topCats.forEach(cat => {
-        const link = document.createElement('a');
-        link.className = 'dropdown-item';
-        link.href = `/c/${cat.slug}/`;
-        link.textContent = cat.name;
-        menu.appendChild(link);
-      });
-      navList.insertBefore(li, navList.firstChild ? navList.children[1] : null);
+        li.innerHTML = `<a class="nav-link dropdown-toggle" href="#" id="shopDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Shop</a><ul class="dropdown-menu" aria-labelledby="shopDropdown"></ul>`;
+        const menu = li.querySelector('.dropdown-menu');
+        const toggle = li.querySelector('#shopDropdown');
+        topCats.forEach(cat => {
+          const link = document.createElement('a');
+          link.className = 'dropdown-item';
+          link.href = `/c/${cat.slug}/`;
+          link.textContent = cat.name;
+          menu.appendChild(link);
+        });
+        navList.insertBefore(li, navList.firstChild ? navList.children[1] : null);
+        const dd = bootstrap.Dropdown.getOrCreateInstance(toggle);
+        toggle.addEventListener('keydown', e => {
+          if (e.key === 'Escape') {
+            dd.hide();
+            toggle.focus();
+          }
+        });
+        menu.addEventListener('keydown', e => {
+          if (e.key === 'Escape') {
+            dd.hide();
+            toggle.focus();
+          }
+        });
+        toggle.addEventListener('shown.bs.dropdown', () => {
+          toggle.setAttribute('aria-expanded', 'true');
+        });
+        toggle.addEventListener('hidden.bs.dropdown', () => {
+          toggle.setAttribute('aria-expanded', 'false');
+          toggle.focus();
+        });
 
       if (window.location.pathname.startsWith('/c/')) {
         const slug = window.location.pathname.split('/')[2];

--- a/assets/js/home-page.js
+++ b/assets/js/home-page.js
@@ -1,0 +1,51 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const container = document.getElementById('home-categories');
+  if (!container) return;
+  try {
+    const categories = await StorefrontRuntime.loadCategories();
+    const topCats = categories.filter(c => !c.parent)
+      .sort((a,b)=>(a.sortOrder - b.sortOrder) || a.name.localeCompare(b.name));
+    const limit = 6;
+    topCats.slice(0, limit).forEach(cat => {
+      const col = document.createElement('div');
+      col.className = 'col-6 col-md-4 col-lg-3 mb-4 text-center';
+      const link = document.createElement('a');
+      link.href = `/c/${cat.slug}/`;
+      link.className = 'd-block text-decoration-none text-dark p-2';
+      link.style.minHeight = '44px';
+      if (cat.image) {
+        const img = document.createElement('img');
+        img.src = cat.image;
+        img.alt = cat.name;
+        img.loading = 'lazy';
+        img.className = 'img-fluid mb-2';
+        img.style.objectFit = 'cover';
+        img.style.aspectRatio = '1 / 1';
+        link.appendChild(img);
+      }
+      const span = document.createElement('span');
+      span.textContent = cat.name;
+      link.appendChild(span);
+      col.appendChild(link);
+      container.appendChild(col);
+    });
+    if (topCats.length > limit) {
+      const wrap = document.getElementById('view-all-categories-wrapper');
+      if (wrap) {
+        wrap.classList.remove('d-none');
+        const view = document.getElementById('view-all-categories');
+        view.addEventListener('click', e => {
+          e.preventDefault();
+          const toggle = document.getElementById('shopDropdown');
+          if (toggle) {
+            const dd = bootstrap.Dropdown.getOrCreateInstance(toggle);
+            dd.show();
+            toggle.focus();
+          }
+        });
+      }
+    }
+  } catch (e) {
+    console.error(e);
+  }
+});

--- a/assets/js/product-page.js
+++ b/assets/js/product-page.js
@@ -8,25 +8,62 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (!product) {
       return render404();
     }
-    document.title = `${product.name} | 4D Cosmetics`;
-    document.getElementById('canonical-link').setAttribute('href', `/p/${product.slug}`);
-    const meta = document.querySelector('meta[name="description"]');
-    if (meta && product.shortDescription) {
-      meta.setAttribute('content', product.shortDescription.slice(0,160));
-    }
+      const canonicalUrl = `${window.location.origin}/p/${product.slug}`;
+      document.title = `${product.name} | 4D Cosmetics`;
+      document.getElementById('canonical-link').setAttribute('href', canonicalUrl);
+      const meta = document.querySelector('meta[name="description"]');
+      let metaDesc = '';
+      if (meta && product.shortDescription) {
+        metaDesc = product.shortDescription.slice(0,160);
+        meta.setAttribute('content', metaDesc);
+      }
+      document.getElementById('og-title').setAttribute('content', `${product.name} | 4D Cosmetics`);
+      if (metaDesc) document.getElementById('og-description').setAttribute('content', metaDesc); else document.getElementById('og-description').remove();
+      document.getElementById('og-url').setAttribute('content', canonicalUrl);
+      if (product.images && product.images.length) {
+        document.getElementById('og-image').setAttribute('content', product.images[0]);
+      } else {
+        document.getElementById('og-image').remove();
+      }
 
-    document.getElementById('product-title').textContent = product.name;
-    document.getElementById('product-price').textContent = StorefrontRuntime.formatPrice(product.price, product.currency);
-    document.getElementById('stock-status').textContent = product.inStock ? 'In stock' : 'Out of stock';
-    document.getElementById('short-description').textContent = product.shortDescription || '';
-    if (product.descriptionHTML) {
-      document.getElementById('details').innerHTML = product.descriptionHTML;
-    }
+      document.getElementById('product-title').textContent = product.name;
+      document.getElementById('product-price').textContent = StorefrontRuntime.formatPrice(product.price, product.currency);
+      document.getElementById('stock-status').textContent = product.inStock ? 'In stock' : 'Out of stock';
+      document.getElementById('short-description').textContent = product.shortDescription || '';
+      if (product.descriptionHTML) {
+        document.getElementById('details').innerHTML = product.descriptionHTML;
+      }
 
-    const breadcrumb = document.getElementById('breadcrumb');
-    const firstCatSlug = product.categories && product.categories[0];
-    let firstCat = firstCatSlug ? StorefrontRuntime.findCategoryBySlug(firstCatSlug) : null;
-    breadcrumb.innerHTML = `<li class="breadcrumb-item"><a href="/">Home</a></li>` + (firstCat ? `<li class="breadcrumb-item"><a href="/c/${firstCat.slug}/">${firstCat.name}</a></li>` : '') + `<li class="breadcrumb-item active" aria-current="page">${product.name}</li>`;
+      const breadcrumb = document.getElementById('breadcrumb');
+      const firstCatSlug = product.categories && product.categories[0];
+      let firstCat = firstCatSlug ? StorefrontRuntime.findCategoryBySlug(firstCatSlug) : null;
+      breadcrumb.innerHTML = `<li class="breadcrumb-item"><a href="/">Home</a></li>` + (firstCat ? `<li class="breadcrumb-item"><a href="/c/${firstCat.slug}/">${firstCat.name}</a></li>` : '') + `<li class="breadcrumb-item active" aria-current="page">${product.name}</li>`;
+      const ld = [];
+      ld.push({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {"@type":"ListItem","position":1,"name":"Home","item":`${window.location.origin}/`},
+          ...(firstCat ? [{"@type":"ListItem","position":2,"name":firstCat.name,"item":`${window.location.origin}/c/${firstCat.slug}/`}] : []),
+          {"@type":"ListItem","position": firstCat ? 3 : 2, "name": product.name, "item": canonicalUrl}
+        ]
+      });
+      const prodSchema = {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "name": product.name,
+        ...(product.images ? {"image": product.images} : {}),
+        ...(product.sku ? {"sku": product.sku} : {}),
+        "offers": {
+          "@type": "Offer",
+          "price": product.price,
+          "priceCurrency": product.currency,
+          "availability": product.inStock ? "https://schema.org/InStock" : "https://schema.org/OutOfStock"
+        }
+      };
+      if (product.brand) prodSchema.brand = {"@type":"Brand","name":product.brand};
+      ld.push(prodSchema);
+      document.getElementById('ld-json').textContent = JSON.stringify(ld);
 
     const badges = document.getElementById('category-badges');
     (product.categories || []).forEach(cs => {
@@ -51,23 +88,26 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
     backLink.href = backHref;
 
-    const mainImg = document.getElementById('main-image');
-    const thumbs = document.getElementById('image-thumbs');
-    if (product.images && product.images.length) {
-      mainImg.src = product.images[0];
-      product.images.forEach((img, idx) => {
-        const t = document.createElement('img');
-        t.src = img;
-        t.className = 'img-thumbnail me-2';
-        t.style.width = '60px';
-        t.style.height = '60px';
-        t.style.objectFit = 'cover';
-        t.addEventListener('click', () => {
-          mainImg.src = img;
+      const mainImg = document.getElementById('main-image');
+      const thumbs = document.getElementById('image-thumbs');
+      if (product.images && product.images.length) {
+        mainImg.src = product.images[0];
+        mainImg.alt = product.name;
+        product.images.forEach((img) => {
+          const t = document.createElement('img');
+          t.src = img;
+          t.className = 'img-thumbnail me-2';
+          t.style.width = '60px';
+          t.style.height = '60px';
+          t.style.objectFit = 'cover';
+          t.loading = 'lazy';
+          t.alt = product.name;
+          t.addEventListener('click', () => {
+            mainImg.src = img;
+          });
+          thumbs.appendChild(t);
         });
-        thumbs.appendChild(t);
-      });
-    }
+      }
   } catch (e) {
     console.error(e);
     const container = document.querySelector('.container');

--- a/c/index.html
+++ b/c/index.html
@@ -1,11 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Category | 4D Cosmetics</title>
-  <meta name="description" content="">
-  <link rel="canonical" id="canonical-link" href="">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Category | 4D Cosmetics</title>
+    <meta name="description" content="">
+    <link rel="canonical" id="canonical-link" href="">
+    <meta property="og:title" content="" id="og-title">
+    <meta property="og:description" content="" id="og-description">
+    <meta property="og:url" content="" id="og-url">
+    <meta property="og:image" content="" id="og-image">
+    <script type="application/ld+json" id="ld-json"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">

--- a/index.html
+++ b/index.html
@@ -28,13 +28,23 @@
     </div>
   </nav>
 
-  <section class="hero" style="background-image:url('https://images.unsplash.com/photo-1522335789203-aabd1fc54bc9?auto=format&fit=crop&w=1200&q=80');">
-    <div class="container">
-      <h1>Beauty in Four Dimensions</h1>
-      <p>Discover premium skincare and makeup for every you.</p>
-      <a href="products.html" class="btn btn-primary mt-3">Shop Now</a>
-    </div>
-  </section>
+    <section class="hero" style="background-image:url('https://images.unsplash.com/photo-1522335789203-aabd1fc54bc9?auto=format&fit=crop&w=1200&q=80');">
+      <div class="container">
+        <h1>Beauty in Four Dimensions</h1>
+        <p>Discover premium skincare and makeup for every you.</p>
+        <a href="products.html" class="btn btn-primary mt-3">Shop Now</a>
+      </div>
+    </section>
+
+    <section class="py-5 bg-light">
+      <div class="container">
+        <h2 class="mb-4 text-center">Shop by Category</h2>
+        <div class="row" id="home-categories"></div>
+        <div class="text-center d-none" id="view-all-categories-wrapper">
+          <a href="#" id="view-all-categories">View all categories</a>
+        </div>
+      </div>
+    </section>
 
   <section class="py-5">
     <div class="container">
@@ -61,7 +71,8 @@
   <script src="./assets/js/simpleCart.min.js"></script>
   <script src="./assets/js/simpleStore.js"></script>
   <script src="./assets/js/config.js"></script>
-  <script src="./assets/js/storefront-runtime.js"></script>
-  <script src="./assets/js/header-nav.js"></script>
-</body>
-</html>
+    <script src="./assets/js/storefront-runtime.js"></script>
+    <script src="./assets/js/header-nav.js"></script>
+    <script src="./assets/js/home-page.js"></script>
+  </body>
+  </html>

--- a/p/index.html
+++ b/p/index.html
@@ -1,11 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Product | 4D Cosmetics</title>
-  <meta name="description" content="">
-  <link rel="canonical" id="canonical-link" href="">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Product | 4D Cosmetics</title>
+    <meta name="description" content="">
+    <link rel="canonical" id="canonical-link" href="">
+    <meta property="og:title" content="" id="og-title">
+    <meta property="og:description" content="" id="og-description">
+    <meta property="og:url" content="" id="og-url">
+    <meta property="og:image" content="" id="og-image">
+    <script type="application/ld+json" id="ld-json"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
@@ -38,7 +43,7 @@
       <a href="#" id="back-link" class="d-block mb-3">&laquo; Back</a>
       <div class="row">
         <div class="col-md-6">
-          <img id="main-image" class="img-fluid" alt="">
+            <img id="main-image" class="img-fluid" alt="" loading="lazy" style="object-fit:cover;aspect-ratio:1/1;">
           <div class="mt-2" id="image-thumbs"></div>
         </div>
         <div class="col-md-6">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://4dcosmetics.com/</loc></url>
+  <url><loc>https://4dcosmetics.com/c/makeup/</loc></url>
+  <url><loc>https://4dcosmetics.com/c/skin-care/</loc></url>
+  <url><loc>https://4dcosmetics.com/c/fragrance/</loc></url>
+  <url><loc>https://4dcosmetics.com/c/lipstick/</loc></url>
+  <url><loc>https://4dcosmetics.com/c/foundation/</loc></url>
+  <url><loc>https://4dcosmetics.com/c/primer/</loc></url>
+  <url><loc>https://4dcosmetics.com/c/serums/</loc></url>
+  <url><loc>https://4dcosmetics.com/c/creams/</loc></url>
+  <url><loc>https://4dcosmetics.com/c/perfume/</loc></url>
+  <url><loc>https://4dcosmetics.com/p/velvet-matte-lipstick</loc></url>
+  <url><loc>https://4dcosmetics.com/p/hydrating-foundation</loc></url>
+  <url><loc>https://4dcosmetics.com/p/vitamin-c-serum</loc></url>
+  <url><loc>https://4dcosmetics.com/p/moisturizing-cream</loc></url>
+  <url><loc>https://4dcosmetics.com/p/blossom-perfume</loc></url>
+  <url><loc>https://4dcosmetics.com/p/rbory-face-primer</loc></url>
+  <url><loc>https://4dcosmetics.com/p/art-skin-velvet-lipstick-6-pcs</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary
- Add client-side 404 fallback to load category and product shells for deep links
- Surface top categories on the homepage with lazy-loaded tiles
- Enhance category/product pages with canonical & OG tags, JSON-LD, image lazy-loading, and accessible pagination
- Generate sitemap entries for categories and products

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a46c5af14883208006979eb9b54038