### PR TITLE
Harden routing and polish category/product pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,18 +4,34 @@
   <meta charset="UTF-8">
   <title>Page Not Found | 4D Cosmetics</title>
   <script>
-    const path = window.location.pathname;
-    if (path.startsWith('/c/') || path.startsWith('/p/')) {
-      const shell = path.startsWith('/c/') ? '/c/' : '/p/';
-      fetch(shell)
-        .then(r => r.ok ? r.text() : Promise.reject())
-        .then(html => {
-          document.open();
-          document.write(html);
-          document.close();
-        })
-        .catch(() => {});
-    }
+    (function () {
+      const loc = window.location;
+      let path = loc.pathname;
+      const isCategory = path.startsWith('/c/');
+      const isProduct = path.startsWith('/p/');
+      if (isCategory || isProduct) {
+        const parts = path.split('/').filter(Boolean);
+        const slug = parts[1];
+        if (isCategory && !path.endsWith('/')) {
+          path = `/c/${slug}/`;
+          history.replaceState(null, '', path + loc.search);
+        }
+        if (isProduct && path.endsWith('/')) {
+          path = `/p/${slug}`;
+          history.replaceState(null, '', path + loc.search);
+        }
+        const shell = isCategory ? '/c/' : '/p/';
+        fetch(shell)
+          .then(r => (r.ok ? r.text() : Promise.reject()))
+          .then(html => {
+            html = html.replace('<head>', '<head><base href="/">');
+            document.open();
+            document.write(html);
+            document.close();
+          })
+          .catch(() => {});
+      }
+    })();
   </script>
 </head>
 <body>

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ or manually install using the latest [release](https://github.com/chrisdiana/sim
 
 4.Add additional products in the `products.json` file.
 
+# Categories & Products
+
+- Category pages live at `/c/{slug}/` (note the trailing slash). Product pages use `/p/{slug}` without a trailing slash.
+- Edit `assets/data/categories.json` and `assets/data/products.json` to manage content. Slugs must remain unique and URL-safe.
+- GitHub Pages serves `404.html` for deep links. The fallback script loads the proper category or product shell while preserving the original URL. When testing locally, run any static server and navigate directly to `/c/{slug}/` or `/p/{slug}` to verify the handoff.
+- To add a new category or product:
+  - Add its entry to the appropriate JSON file.
+  - Ensure the URL is listed in `sitemap.xml`.
+  - New top-level categories automatically appear in the homepage tiles and the header “Shop” menu, and all pages emit correct canonical, Open Graph, and JSON-LD metadata.
+
 # Using Plugins
 
 To use a plugin, add a reference just before your `config.js` file

--- a/assets/js/category-page.js
+++ b/assets/js/category-page.js
@@ -1,7 +1,8 @@
 document.addEventListener('DOMContentLoaded', async () => {
   const parts = window.location.pathname.split('/').filter(Boolean);
   const slug = parts[1];
-  const pageNum = parseInt(StorefrontRuntime.getQueryParam('page') || '1', 10);
+  let pageNum = parseInt(StorefrontRuntime.getQueryParam('page') || '1', 10);
+  if (isNaN(pageNum) || pageNum < 1) pageNum = 1;
   const perPage = 12;
   try {
     await StorefrontRuntime.loadCategories();
@@ -20,6 +21,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         tmp.innerHTML = category.descriptionHTML;
         metaDesc = tmp.textContent.trim().slice(0,160);
         meta.setAttribute('content', metaDesc);
+      } else if (meta) {
+        meta.remove();
       }
       document.getElementById('og-title').setAttribute('content', `${category.name} | 4D Cosmetics`);
       if (metaDesc) document.getElementById('og-description').setAttribute('content', metaDesc); else document.getElementById('og-description').remove();
@@ -71,8 +74,19 @@ document.addEventListener('DOMContentLoaded', async () => {
       const p = document.createElement('p');
       p.textContent = 'No products in this category yet.';
       const link = document.createElement('a');
-      link.href = '/';
+      link.href = '#';
       link.textContent = 'Browse all categories';
+      link.addEventListener('click', e => {
+        e.preventDefault();
+        const toggle = document.getElementById('shopDropdown');
+        if (toggle) {
+          const dd = bootstrap.Dropdown.getOrCreateInstance(toggle);
+          dd.show();
+          toggle.focus();
+        } else {
+          window.location.href = '/';
+        }
+      });
       grid.appendChild(p);
       grid.appendChild(link);
       return;
@@ -81,7 +95,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     pageItems.forEach(prod => {
       const col = document.createElement('div');
       col.className = 'col-6 col-md-4 col-lg-3 mb-4';
-        col.innerHTML = `<a href="/p/${prod.slug}" class="text-decoration-none text-dark"><div class="card h-100"><img src="${prod.images[0]}" class="card-img-top" alt="${prod.name}" loading="lazy" style="object-fit:cover;aspect-ratio:1/1;"><div class="card-body p-2"><h6 class="card-title">${prod.name}</h6><p class="card-text mb-1">${StorefrontRuntime.formatPrice(prod.price, prod.currency)}</p>${prod.inStock ? '' : '<span class="badge bg-secondary">Out of stock</span>'}</div></div></a>`;
+      col.innerHTML = `<a href="/p/${prod.slug}" class="text-decoration-none text-dark" style="display:block;min-width:44px;min-height:44px;"><div class="card h-100"><img src="${prod.images[0]}" class="card-img-top" alt="${prod.name}" loading="lazy" width="300" height="300" style="object-fit:cover;aspect-ratio:1/1;"><div class="card-body p-2"><h6 class="card-title">${prod.name}</h6><p class="card-text mb-1">${StorefrontRuntime.formatPrice(prod.price, prod.currency)}</p>${prod.inStock ? '' : '<span class="badge bg-secondary">Out of stock</span>'}</div></div></a>`;
       grid.appendChild(col);
     });
     const totalPages = Math.ceil(products.length / perPage);
@@ -93,6 +107,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         const prevA = document.createElement('a');
         prevA.className = 'page-link';
         prevA.textContent = 'Previous';
+        prevA.style.minWidth = '44px';
+        prevA.style.minHeight = '44px';
         if (pageNum === 1) {
           prev.className = 'page-item disabled';
           prevA.setAttribute('aria-disabled', 'true');
@@ -109,6 +125,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         const a = document.createElement('a');
         a.className = 'page-link';
         a.textContent = i;
+        a.style.minWidth = '44px';
+        a.style.minHeight = '44px';
         if (i !== pageNum) a.href = `?page=${i}`;
         li.appendChild(a);
         ulp.appendChild(li);
@@ -117,6 +135,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         const nextA = document.createElement('a');
         nextA.className = 'page-link';
         nextA.textContent = 'Next';
+        nextA.style.minWidth = '44px';
+        nextA.style.minHeight = '44px';
         if (pageNum === totalPages) {
           next.className = 'page-item disabled';
           nextA.setAttribute('aria-disabled', 'true');

--- a/assets/js/header-nav.js
+++ b/assets/js/header-nav.js
@@ -30,6 +30,11 @@ document.addEventListener('DOMContentLoaded', async () => {
           if (e.key === 'Escape') {
             dd.hide();
             toggle.focus();
+          } else if (e.key === ' ') {
+            e.preventDefault();
+            if (e.target && e.target.tagName === 'A') {
+              e.target.click();
+            }
           }
         });
         toggle.addEventListener('shown.bs.dropdown', () => {

--- a/assets/js/home-page.js
+++ b/assets/js/home-page.js
@@ -13,11 +13,14 @@ document.addEventListener('DOMContentLoaded', async () => {
       link.href = `/c/${cat.slug}/`;
       link.className = 'd-block text-decoration-none text-dark p-2';
       link.style.minHeight = '44px';
+      link.style.minWidth = '44px';
       if (cat.image) {
         const img = document.createElement('img');
         img.src = cat.image;
         img.alt = cat.name;
         img.loading = 'lazy';
+        img.width = 300;
+        img.height = 300;
         img.className = 'img-fluid mb-2';
         img.style.objectFit = 'cover';
         img.style.aspectRatio = '1 / 1';

--- a/assets/js/product-page.js
+++ b/assets/js/product-page.js
@@ -16,6 +16,8 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (meta && product.shortDescription) {
         metaDesc = product.shortDescription.slice(0,160);
         meta.setAttribute('content', metaDesc);
+      } else if (meta) {
+        meta.remove();
       }
       document.getElementById('og-title').setAttribute('content', `${product.name} | 4D Cosmetics`);
       if (metaDesc) document.getElementById('og-description').setAttribute('content', metaDesc); else document.getElementById('og-description').remove();
@@ -52,7 +54,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         "@context": "https://schema.org",
         "@type": "Product",
         "name": product.name,
-        ...(product.images ? {"image": product.images} : {}),
+        ...(product.images && product.images.length ? {"image": product.images} : {}),
         ...(product.sku ? {"sku": product.sku} : {}),
         "offers": {
           "@type": "Offer",
@@ -78,10 +80,12 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const backLink = document.getElementById('back-link');
     let backHref = '/';
-    if (document.referrer && document.referrer.includes('/c/')) {
+    if (document.referrer) {
       try {
         const refUrl = new URL(document.referrer);
-        backHref = refUrl.pathname;
+        if (refUrl.origin === window.location.origin && refUrl.pathname.startsWith('/c/')) {
+          backHref = refUrl.pathname;
+        }
       } catch {}
     } else if (firstCat) {
       backHref = `/c/${firstCat.slug}/`;
@@ -93,6 +97,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (product.images && product.images.length) {
         mainImg.src = product.images[0];
         mainImg.alt = product.name;
+        mainImg.loading = 'eager';
         product.images.forEach((img) => {
           const t = document.createElement('img');
           t.src = img;

--- a/p/index.html
+++ b/p/index.html
@@ -43,7 +43,7 @@
       <a href="#" id="back-link" class="d-block mb-3">&laquo; Back</a>
       <div class="row">
         <div class="col-md-6">
-            <img id="main-image" class="img-fluid" alt="" loading="lazy" style="object-fit:cover;aspect-ratio:1/1;">
+            <img id="main-image" class="img-fluid" alt="" style="object-fit:cover;aspect-ratio:1/1;" width="600" height="600">
           <div class="mt-2" id="image-thumbs"></div>
         </div>
         <div class="col-md-6">

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Allow: /c/
 Allow: /p/
+Sitemap: https://4dcosmetics.com/sitemap.xml


### PR DESCRIPTION
## Summary
- Normalize deep links through 404 fallback and ensure assets load with canonical category/product URLs
- Refine category and product pages with conditional meta/OG tags, JSON-LD, accessible pagination, and lazy-loaded images
- Document category/product management and expose sitemap in robots.txt

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node <<'NODE' ...` (JSON-LD ok)
- `node -e "const fs=require('fs');const cats=JSON.parse(fs.readFileSync('assets/data/categories.json'));const prods=JSON.parse(fs.readFileSync('assets/data/products.json'));const sitemap=fs.readFileSync('sitemap.xml','utf8');const urlCount=(sitemap.match(/<loc>/g)||[]).length;console.log('categories',cats.length,'products',prods.length,'sitemap URLs',urlCount);"`

------
https://chatgpt.com/codex/tasks/task_e_68a46f04548c8320b1d8a320946bb43b