### PR TITLE
Add category sorting, filtering, and browse page

### DIFF
--- a/404.html
+++ b/404.html
@@ -37,5 +37,6 @@
 <body>
   <h1>Page not found</h1>
   <p><a href="/">Home</a></p>
+  <p><a href="/categories/">Browse all categories</a></p>
 </body>
 </html>

--- a/assets/js/categories-page.js
+++ b/assets/js/categories-page.js
@@ -1,0 +1,57 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  try {
+    const categories = await StorefrontRuntime.loadCategories();
+    const top = categories.filter(c => !c.parent)
+      .sort((a,b)=>(a.sortOrder - b.sortOrder) || a.name.localeCompare(b.name));
+    const container = document.getElementById('all-categories');
+    const childrenMap = categories.reduce((acc, c) => {
+      if (c.parent) {
+        (acc[c.parent] = acc[c.parent] || []).push(c);
+      }
+      return acc;
+    }, {});
+    top.forEach(cat => {
+      const col = document.createElement('div');
+      col.className = 'col-6 col-md-4 col-lg-3 mb-4';
+      const card = document.createElement('a');
+      card.href = `/c/${cat.slug}/`;
+      card.className = 'text-decoration-none text-dark d-block h-100 p-2';
+      card.style.minHeight = '44px';
+      card.style.minWidth = '44px';
+      if (cat.image) {
+        const img = document.createElement('img');
+        img.src = cat.image;
+        img.alt = cat.name;
+        img.loading = 'lazy';
+        img.width = 300;
+        img.height = 300;
+        img.className = 'img-fluid mb-2';
+        img.style.objectFit = 'cover';
+        img.style.aspectRatio = '1/1';
+        card.appendChild(img);
+      }
+      const title = document.createElement('h6');
+      title.textContent = cat.name;
+      card.appendChild(title);
+      const childWrap = document.createElement('div');
+      (childrenMap[cat.slug]||[])
+        .sort((a,b)=>(a.sortOrder - b.sortOrder)||a.name.localeCompare(b.name))
+        .forEach(ch => {
+          const chip = document.createElement('a');
+          chip.href = `/c/${ch.slug}/`;
+          chip.textContent = ch.name;
+          chip.className = 'badge bg-light text-dark border me-1';
+          chip.style.minHeight = '44px';
+          chip.style.display = 'inline-flex';
+          chip.style.alignItems = 'center';
+          chip.style.padding = '0.25rem 0.5rem';
+          childWrap.appendChild(chip);
+        });
+      card.appendChild(childWrap);
+      col.appendChild(card);
+      container.appendChild(col);
+    });
+  } catch (e) {
+    console.error(e);
+  }
+});

--- a/assets/js/category-page.js
+++ b/assets/js/category-page.js
@@ -1,157 +1,345 @@
 document.addEventListener('DOMContentLoaded', async () => {
   const parts = window.location.pathname.split('/').filter(Boolean);
   const slug = parts[1];
-  let pageNum = parseInt(StorefrontRuntime.getQueryParam('page') || '1', 10);
-  if (isNaN(pageNum) || pageNum < 1) pageNum = 1;
   const perPage = 12;
+  let state = {
+    page: 1,
+    sort: 'featured',
+    brand: [],
+    inStock: false,
+    priceMin: null,
+    priceMax: null,
+    tags: []
+  };
+  function parseURL() {
+    const params = new URLSearchParams(window.location.search);
+    state.page = parseInt(params.get('page') || '1', 10);
+    if (isNaN(state.page) || state.page < 1) state.page = 1;
+    state.sort = params.get('sort') || 'featured';
+    state.brand = (params.get('brand') || '').split(',').filter(Boolean).map(decodeURIComponent);
+    state.inStock = params.get('inStock') === 'true';
+    const pmin = parseFloat(params.get('priceMin'));
+    const pmax = parseFloat(params.get('priceMax'));
+    state.priceMin = isNaN(pmin) ? null : pmin;
+    state.priceMax = isNaN(pmax) ? null : pmax;
+    if (state.priceMin !== null && state.priceMax !== null && state.priceMin > state.priceMax) {
+      // swap if user provided inverted range
+      const tmp = state.priceMin; state.priceMin = state.priceMax; state.priceMax = tmp;
+    }
+    state.tags = (params.get('tags') || '').split(',').filter(Boolean).map(decodeURIComponent);
+  }
+  function buildQuery(extra) {
+    const params = new URLSearchParams();
+    const s = {...state, ...extra};
+    if (s.page) params.set('page', s.page);
+    if (s.sort && s.sort !== 'featured') params.set('sort', s.sort);
+    if (s.brand.length) params.set('brand', s.brand.join(','));
+    if (s.inStock) params.set('inStock', 'true');
+    if (s.priceMin !== null) params.set('priceMin', s.priceMin);
+    if (s.priceMax !== null) params.set('priceMax', s.priceMax);
+    if (s.tags.length) params.set('tags', s.tags.join(','));
+    const qs = params.toString();
+    return qs ? `?${qs}` : '';
+  }
+  function pushURL() {
+    history.pushState({}, '', `${window.location.pathname}${buildQuery()}`);
+  }
+  function replaceURL() {
+    history.replaceState({}, '', `${window.location.pathname}${buildQuery()}`);
+  }
+  function readForm(form) {
+    const fd = new FormData(form);
+    state.brand = fd.getAll('brand');
+    state.tags = fd.getAll('tags');
+    state.inStock = fd.get('inStock') === 'on';
+    const pmin = parseFloat(fd.get('priceMin'));
+    const pmax = parseFloat(fd.get('priceMax'));
+    state.priceMin = isNaN(pmin) ? null : pmin;
+    state.priceMax = isNaN(pmax) ? null : pmax;
+    if (state.priceMin !== null && state.priceMax !== null && state.priceMin > state.priceMax) {
+      const tmp = state.priceMin; state.priceMin = state.priceMax; state.priceMax = tmp;
+    }
+  }
+  function setForm(form) {
+    if (!form) return;
+    form.querySelectorAll('input[name="brand"]').forEach(cb => {
+      cb.checked = state.brand.includes(cb.value);
+    });
+    const inStockEl = form.querySelector('input[name="inStock"]');
+    if (inStockEl) inStockEl.checked = state.inStock;
+    const minEl = form.querySelector('input[name="priceMin"]');
+    if (minEl) minEl.value = state.priceMin !== null ? state.priceMin : '';
+    const maxEl = form.querySelector('input[name="priceMax"]');
+    if (maxEl) maxEl.value = state.priceMax !== null ? state.priceMax : '';
+    form.querySelectorAll('input[name="tags"]').forEach(cb => {
+      cb.checked = state.tags.includes(cb.value);
+    });
+  }
+  function clearFilters() {
+    state.brand = [];
+    state.inStock = false;
+    state.priceMin = null;
+    state.priceMax = null;
+    state.tags = [];
+    state.page = 1;
+    pushURL();
+    setForm(document.getElementById('filters-desktop-form'));
+    setForm(document.getElementById('filters-mobile'));
+    render();
+  }
+  parseURL();
+  window.addEventListener('popstate', () => {
+    parseURL();
+    setForm(document.getElementById('filters-desktop-form'));
+    setForm(document.getElementById('filters-mobile'));
+    render(false);
+  });
   try {
     await StorefrontRuntime.loadCategories();
     await StorefrontRuntime.loadProducts();
     const category = StorefrontRuntime.findCategoryBySlug(slug);
-    if (!category) {
-      return render404();
-    }
-      const canonicalUrl = `${window.location.origin}/c/${category.slug}/`;
-      document.title = `${category.name} | 4D Cosmetics`;
-      document.getElementById('canonical-link').setAttribute('href', canonicalUrl);
-      const meta = document.querySelector('meta[name="description"]');
-      let metaDesc = '';
-      if (meta && category.descriptionHTML) {
-        const tmp = document.createElement('div');
-        tmp.innerHTML = category.descriptionHTML;
-        metaDesc = tmp.textContent.trim().slice(0,160);
-        meta.setAttribute('content', metaDesc);
-      } else if (meta) {
-        meta.remove();
-      }
-      document.getElementById('og-title').setAttribute('content', `${category.name} | 4D Cosmetics`);
-      if (metaDesc) document.getElementById('og-description').setAttribute('content', metaDesc); else document.getElementById('og-description').remove();
-      document.getElementById('og-url').setAttribute('content', canonicalUrl);
-      if (category.image) {
-        document.getElementById('og-image').setAttribute('content', category.image);
-      } else {
-        document.getElementById('og-image').remove();
-      }
-      const ld = {
-        "@context": "https://schema.org",
-        "@type": "BreadcrumbList",
-        "itemListElement": [
-          {"@type": "ListItem", "position": 1, "name": "Home", "item": `${window.location.origin}/`},
-          {"@type": "ListItem", "position": 2, "name": category.name, "item": canonicalUrl}
-        ]
-      };
-      document.getElementById('ld-json').textContent = JSON.stringify(ld);
+    if (!category) return render404();
+    const canonicalUrl = `${window.location.origin}/c/${category.slug}/`;
+    document.title = `${category.name} | 4D Cosmetics`;
+    document.getElementById('canonical-link').setAttribute('href', canonicalUrl);
+    const meta = document.querySelector('meta[name="description"]');
+    let metaDesc = '';
+    if (meta && category.descriptionHTML) {
+      const tmp = document.createElement('div');
+      tmp.innerHTML = category.descriptionHTML;
+      metaDesc = tmp.textContent.trim().slice(0,160);
+      meta.setAttribute('content', metaDesc);
+    } else if (meta) meta.remove();
+    document.getElementById('og-title').setAttribute('content', `${category.name} | 4D Cosmetics`);
+    if (metaDesc) document.getElementById('og-description').setAttribute('content', metaDesc); else document.getElementById('og-description').remove();
+    document.getElementById('og-url').setAttribute('content', canonicalUrl);
+    if (category.image) document.getElementById('og-image').setAttribute('content', category.image); else document.getElementById('og-image').remove();
+    const ld = {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type":"ListItem","position":1,"name":"Home","item":`${window.location.origin}/`},
+        {"@type":"ListItem","position":2,"name":category.name,"item":canonicalUrl}
+      ]
+    };
+    document.getElementById('ld-json').textContent = JSON.stringify(ld);
     document.getElementById('category-title').textContent = category.name;
-    if (category.descriptionHTML) {
-      document.getElementById('category-description').innerHTML = category.descriptionHTML;
-    }
+    if (category.descriptionHTML) document.getElementById('category-description').innerHTML = category.descriptionHTML;
     const breadcrumb = document.getElementById('breadcrumb');
     breadcrumb.innerHTML = `<li class="breadcrumb-item"><a href="/">Home</a></li><li class="breadcrumb-item active" aria-current="page">${category.name}</li>`;
 
-    // sidebar
-    const side = document.getElementById('category-sidebar');
+    // sidebar categories
+    const sideList = document.getElementById('category-sidebar-list');
     const allCats = await StorefrontRuntime.loadCategories();
-    const topCats = allCats.filter(c => !c.parent).sort((a,b)=>(a.sortOrder-b.sortOrder)||a.name.localeCompare(b.name));
-    const ul = document.createElement('ul');
-    ul.className = 'list-unstyled';
-    topCats.forEach(c => {
-      const li = document.createElement('li');
-      const a = document.createElement('a');
-        a.href = `/c/${c.slug}/`;
-        a.textContent = c.name;
-        if (c.slug === category.slug) {
-          a.classList.add('fw-bold');
-          a.setAttribute('aria-current', 'page');
-        }
-      li.appendChild(a);
-      ul.appendChild(li);
-    });
-    side.appendChild(ul);
+    const topCats = allCats.filter(c=>!c.parent).sort((a,b)=>(a.sortOrder-b.sortOrder)||a.name.localeCompare(b.name));
+    const ul = document.createElement('ul'); ul.className = 'list-unstyled';
+    topCats.forEach(c=>{ const li=document.createElement('li'); const a=document.createElement('a'); a.href=`/c/${c.slug}/`; a.textContent=c.name; if(c.slug===category.slug){a.classList.add('fw-bold');a.setAttribute('aria-current','page');} li.appendChild(a); ul.appendChild(li); });
+    sideList.appendChild(ul);
 
-    const products = StorefrontRuntime.listProductsForCategory(slug);
-    const grid = document.getElementById('product-grid');
-    if (products.length === 0) {
-      const p = document.createElement('p');
-      p.textContent = 'No products in this category yet.';
-      const link = document.createElement('a');
-      link.href = '#';
-      link.textContent = 'Browse all categories';
-      link.addEventListener('click', e => {
-        e.preventDefault();
-        const toggle = document.getElementById('shopDropdown');
-        if (toggle) {
-          const dd = bootstrap.Dropdown.getOrCreateInstance(toggle);
-          dd.show();
-          toggle.focus();
-        } else {
-          window.location.href = '/';
-        }
+    const productsAll = StorefrontRuntime.listProductsForCategory(slug);
+    const brands = Array.from(new Set(productsAll.map(p=>p.brand).filter(Boolean))).sort();
+    const tagsAll = Array.from(new Set(productsAll.flatMap(p=>p.tags||[]))).sort();
+    // sanitize state for unknown values
+    state.brand = state.brand.filter(b=>brands.includes(b));
+    state.tags = state.tags.filter(t=>tagsAll.includes(t));
+    // build filters
+    function renderFilters(container, formId) {
+      const form = document.createElement('form');
+      form.id = formId;
+      form.className = 'mb-3';
+      const acc = document.createElement('div');
+      acc.className = 'accordion';
+      let idx=0;
+      function addSection(title, bodyBuilder) {
+        const item = document.createElement('div'); item.className='accordion-item';
+        const h = document.createElement('h2'); h.className='accordion-header';
+        const btn = document.createElement('button');
+        btn.className='accordion-button collapsed';
+        const collapseId = `collapse-${formId}-${idx++}`;
+        btn.setAttribute('data-bs-toggle','collapse');
+        btn.setAttribute('data-bs-target',`#${collapseId}`);
+        btn.setAttribute('aria-controls',collapseId);
+        btn.type='button';
+        btn.textContent=title;
+        const col = document.createElement('div');
+        col.id = collapseId; col.className='accordion-collapse collapse';
+        const body = document.createElement('div'); body.className='accordion-body';
+        bodyBuilder(body);
+        col.appendChild(body);
+        h.appendChild(btn);
+        item.appendChild(h); item.appendChild(col);
+        acc.appendChild(item);
+      }
+      if (brands.length) {
+        addSection('Brand', body => {
+          brands.forEach(b => {
+            const id = `${formId}-brand-${b.replace(/[^\w]/g,'')}`;
+            const div = document.createElement('div'); div.className='form-check';
+            const input = document.createElement('input'); input.className='form-check-input'; input.type='checkbox'; input.name='brand'; input.value=b; input.id=id; input.style.minWidth='44px'; input.style.minHeight='44px';
+            const label = document.createElement('label'); label.className='form-check-label'; label.setAttribute('for',id); label.textContent=b; label.style.minHeight='44px'; label.style.display='flex'; label.style.alignItems='center';
+            div.appendChild(input); div.appendChild(label); body.appendChild(div);
+          });
+        });
+      }
+      addSection('Availability', body => {
+        const div = document.createElement('div'); div.className='form-check';
+        const input = document.createElement('input'); input.className='form-check-input'; input.type='checkbox'; input.name='inStock'; input.id=`${formId}-inStock`; input.style.minWidth='44px'; input.style.minHeight='44px';
+        const label = document.createElement('label'); label.className='form-check-label'; label.setAttribute('for',`${formId}-inStock`); label.textContent='Only show in-stock'; label.style.minHeight='44px'; label.style.display='flex'; label.style.alignItems='center';
+        div.appendChild(input); div.appendChild(label); body.appendChild(div);
       });
-      grid.appendChild(p);
-      grid.appendChild(link);
-      return;
+      addSection('Price', body => {
+        const minGroup = document.createElement('div'); minGroup.className='mb-2';
+        const minLabel = document.createElement('label'); minLabel.setAttribute('for',`${formId}-priceMin`); minLabel.textContent='Min';
+        const minInput = document.createElement('input'); minInput.type='number'; minInput.name='priceMin'; minInput.id=`${formId}-priceMin`; minInput.className='form-control'; minInput.style.minHeight='44px';
+        minGroup.appendChild(minLabel); minGroup.appendChild(minInput); body.appendChild(minGroup);
+        const maxGroup = document.createElement('div');
+        const maxLabel = document.createElement('label'); maxLabel.setAttribute('for',`${formId}-priceMax`); maxLabel.textContent='Max';
+        const maxInput = document.createElement('input'); maxInput.type='number'; maxInput.name='priceMax'; maxInput.id=`${formId}-priceMax`; maxInput.className='form-control'; maxInput.style.minHeight='44px';
+        maxGroup.appendChild(maxLabel); maxGroup.appendChild(maxInput); body.appendChild(maxGroup);
+      });
+      if (tagsAll.length) {
+        addSection('Tags', body => {
+          tagsAll.forEach(t => {
+            const id = `${formId}-tag-${t.replace(/[^\w]/g,'')}`;
+            const div = document.createElement('div'); div.className='form-check';
+            const input = document.createElement('input'); input.className='form-check-input'; input.type='checkbox'; input.name='tags'; input.value=t; input.id=id; input.style.minWidth='44px'; input.style.minHeight='44px';
+            const label = document.createElement('label'); label.className='form-check-label'; label.setAttribute('for',id); label.textContent=t; label.style.minHeight='44px'; label.style.display='flex'; label.style.alignItems='center';
+            div.appendChild(input); div.appendChild(label); body.appendChild(div);
+          });
+        });
+      }
+      form.appendChild(acc);
+      if (formId !== 'filters-mobile') {
+        const clear = document.createElement('button');
+        clear.type='button'; clear.textContent='Clear all';
+        clear.className='btn btn-link p-0';
+        clear.id = 'clear-filters-desktop';
+        clear.style.minHeight='44px';
+        clear.style.minWidth='44px';
+        form.appendChild(clear);
+      }
+      container.innerHTML='';
+      container.appendChild(form);
     }
-    const pageItems = StorefrontRuntime.paginateArray(products, pageNum, perPage);
-    pageItems.forEach(prod => {
-      const col = document.createElement('div');
-      col.className = 'col-6 col-md-4 col-lg-3 mb-4';
-      col.innerHTML = `<a href="/p/${prod.slug}" class="text-decoration-none text-dark" style="display:block;min-width:44px;min-height:44px;"><div class="card h-100"><img src="${prod.images[0]}" class="card-img-top" alt="${prod.name}" loading="lazy" width="300" height="300" style="object-fit:cover;aspect-ratio:1/1;"><div class="card-body p-2"><h6 class="card-title">${prod.name}</h6><p class="card-text mb-1">${StorefrontRuntime.formatPrice(prod.price, prod.currency)}</p>${prod.inStock ? '' : '<span class="badge bg-secondary">Out of stock</span>'}</div></div></a>`;
-      grid.appendChild(col);
+    renderFilters(document.getElementById('filters-desktop'),'filters-desktop-form');
+    renderFilters(document.getElementById('filters-mobile'),'filters-mobile');
+    setForm(document.getElementById('filters-desktop-form'));
+    setForm(document.getElementById('filters-mobile'));
+
+    document.getElementById('sort-select').innerHTML = [
+      ['featured','Featured'],
+      ['price_asc','Price: Low to High'],
+      ['price_desc','Price: High to Low'],
+      ['name_asc','Name: A–Z'],
+      ['newest','Newest']
+    ].map(([v,l])=>`<option value="${v}">${l}</option>`).join('');
+    document.getElementById('sort-select').value = state.sort;
+    document.getElementById('sort-select').addEventListener('change', e => {
+      state.sort = e.target.value;
+      state.page = 1;
+      pushURL();
+      render();
     });
-    const totalPages = Math.ceil(products.length / perPage);
-    if (totalPages > 1) {
-      const nav = document.getElementById('pagination');
-      const ulp = document.createElement('ul');
-      ulp.className = 'pagination';
-        const prev = document.createElement('li');
-        const prevA = document.createElement('a');
-        prevA.className = 'page-link';
-        prevA.textContent = 'Previous';
-        prevA.style.minWidth = '44px';
-        prevA.style.minHeight = '44px';
-        if (pageNum === 1) {
-          prev.className = 'page-item disabled';
-          prevA.setAttribute('aria-disabled', 'true');
-          prevA.tabIndex = -1;
-        } else {
-          prev.className = 'page-item';
-          prevA.href = `?page=${pageNum - 1}`;
-        }
-        prev.appendChild(prevA);
-        ulp.appendChild(prev);
-      for (let i = 1; i <= totalPages; i++) {
-        const li = document.createElement('li');
-        li.className = 'page-item' + (i === pageNum ? ' active' : '');
-        const a = document.createElement('a');
-        a.className = 'page-link';
-        a.textContent = i;
-        a.style.minWidth = '44px';
-        a.style.minHeight = '44px';
-        if (i !== pageNum) a.href = `?page=${i}`;
-        li.appendChild(a);
-        ulp.appendChild(li);
+
+    const desktopForm = document.getElementById('filters-desktop-form');
+    desktopForm.addEventListener('change', () => {
+      readForm(desktopForm);
+      state.page = 1;
+      pushURL();
+      setForm(document.getElementById('filters-mobile'));
+      render();
+    });
+    document.getElementById('open-filters').addEventListener('click', () => {
+      const oc = new bootstrap.Offcanvas('#filterDrawer');
+      oc.show();
+    });
+    document.getElementById('apply-filters-mobile').addEventListener('click', e => {
+      e.preventDefault();
+      const form = document.getElementById('filters-mobile');
+      readForm(form);
+      state.page = 1;
+      pushURL();
+      setForm(document.getElementById('filters-desktop-form'));
+      render();
+      bootstrap.Offcanvas.getInstance(document.getElementById('filterDrawer')).hide();
+    });
+    document.getElementById('clear-filters-mobile').addEventListener('click', e => { e.preventDefault(); clearFilters(); bootstrap.Offcanvas.getInstance(document.getElementById('filterDrawer')).hide(); });
+    document.getElementById('clear-filters-desktop').addEventListener('click', e => { e.preventDefault(); clearFilters(); });
+    document.getElementById('filterDrawer').addEventListener('hidden.bs.offcanvas', () => {
+      document.getElementById('open-filters').focus();
+    });
+
+    function sortProducts(arr) {
+      const a = [...arr];
+      switch(state.sort){
+        case 'price_asc': return a.sort((x,y)=>x.price - y.price);
+        case 'price_desc': return a.sort((x,y)=>y.price - x.price);
+        case 'name_asc': return a.sort((x,y)=>x.name.localeCompare(y.name));
+        case 'newest': return a.sort((x,y)=>{
+          const dx = x.createdAt ? Date.parse(x.createdAt) : x.id;
+          const dy = y.createdAt ? Date.parse(y.createdAt) : y.id;
+          // use id fallback when createdAt absent
+          return dy - dx;
+        });
+        default: return a;
       }
-        const next = document.createElement('li');
-        const nextA = document.createElement('a');
-        nextA.className = 'page-link';
-        nextA.textContent = 'Next';
-        nextA.style.minWidth = '44px';
-        nextA.style.minHeight = '44px';
-        if (pageNum === totalPages) {
-          next.className = 'page-item disabled';
-          nextA.setAttribute('aria-disabled', 'true');
-          nextA.tabIndex = -1;
-        } else {
-          next.className = 'page-item';
-          nextA.href = `?page=${pageNum + 1}`;
+    }
+
+    function filterProducts(arr) {
+      return arr.filter(p => {
+        if (state.brand.length && (!p.brand || !state.brand.includes(p.brand))) return false;
+        if (state.inStock && !p.inStock) return false;
+        if (state.priceMin !== null && p.price < state.priceMin) return false;
+        if (state.priceMax !== null && p.price > state.priceMax) return false;
+        if (state.tags.length) {
+          const ptags = p.tags || [];
+          if (!state.tags.some(t => ptags.includes(t))) return false;
         }
-        next.appendChild(nextA);
-        ulp.appendChild(next);
-        nav.appendChild(ulp);
-        const activeLink = nav.querySelector('.active .page-link');
-        if (activeLink) activeLink.focus();
+        return true;
+      });
+    }
+
+    function render(scroll=true) {
+      const grid = document.getElementById('product-grid');
+      grid.innerHTML='';
+      let items = filterProducts(productsAll);
+      items = sortProducts(items);
+      const total = items.length;
+      grid.setAttribute('data-total', total);
+      const productCount = document.getElementById('product-count');
+      productCount.textContent = `${total} products`;
+      const totalPages = Math.ceil(total / perPage) || 1;
+      if (state.page > totalPages) { state.page = totalPages; replaceURL(); }
+      const pageItems = StorefrontRuntime.paginateArray(items, state.page, perPage);
+      if (pageItems.length === 0) {
+        const p = document.createElement('p'); p.textContent = 'No products match your filters.';
+        const link = document.createElement('a'); link.href='#'; link.textContent='Clear filters'; link.addEventListener('click', e=>{e.preventDefault(); clearFilters();});
+        grid.appendChild(p); grid.appendChild(link);
+      } else {
+        pageItems.forEach(prod => {
+          const col = document.createElement('div'); col.className='col-6 col-md-4 col-lg-3 mb-4';
+          col.innerHTML = `<a href="/p/${prod.slug}" class="text-decoration-none text-dark" style="display:block;min-width:44px;min-height:44px;"><div class="card h-100"><img src="${prod.images[0]}" class="card-img-top" alt="${prod.name}" loading="lazy" width="300" height="300" style="object-fit:cover;aspect-ratio:1/1;"><div class="card-body p-2"><h6 class="card-title">${prod.name}</h6><p class="card-text mb-1">${StorefrontRuntime.formatPrice(prod.price, prod.currency)}</p>${prod.inStock ? '' : '<span class="badge bg-secondary">Out of stock</span>'}</div></div></a>`;
+          grid.appendChild(col);
+        });
       }
-      document.getElementById('product-grid').scrollIntoView();
+      const nav = document.getElementById('pagination'); nav.innerHTML='';
+      if (totalPages > 1 && pageItems.length) {
+        const ulp = document.createElement('ul'); ulp.className='pagination';
+        const prev = document.createElement('li'); const prevA=document.createElement('a'); prevA.className='page-link'; prevA.textContent='Previous'; prevA.style.minWidth='44px'; prevA.style.minHeight='44px';
+        if (state.page === 1){ prev.className='page-item disabled'; prevA.setAttribute('aria-disabled','true'); prevA.tabIndex=-1; } else { prev.className='page-item'; prevA.href = buildQuery({page: state.page-1}); }
+        prev.appendChild(prevA); ulp.appendChild(prev);
+        for(let i=1;i<=totalPages;i++){
+          const li=document.createElement('li'); li.className='page-item'+(i===state.page?' active':'');
+          const a=document.createElement('a'); a.className='page-link'; a.textContent=i; a.style.minWidth='44px'; a.style.minHeight='44px'; if(i!==state.page) a.href=buildQuery({page:i}); li.appendChild(a); ulp.appendChild(li);
+        }
+        const next=document.createElement('li'); const nextA=document.createElement('a'); nextA.className='page-link'; nextA.textContent='Next'; nextA.style.minWidth='44px'; nextA.style.minHeight='44px';
+        if (state.page === totalPages){ next.className='page-item disabled'; nextA.setAttribute('aria-disabled','true'); nextA.tabIndex=-1; } else { next.className='page-item'; nextA.href=buildQuery({page: state.page+1}); }
+        next.appendChild(nextA); ulp.appendChild(next); nav.appendChild(ulp);
+      }
+      if (scroll) document.getElementById('product-grid').scrollIntoView();
+    }
+
+    render(false);
   } catch (e) {
     console.error(e);
     const container = document.querySelector('.container');
@@ -161,16 +349,12 @@ document.addEventListener('DOMContentLoaded', async () => {
   function render404() {
     document.title = 'Category not found | 4D Cosmetics';
     const container = document.querySelector('.container');
-    container.innerHTML = '<h1>Category not found</h1><p><a href="/">Home</a></p>';
+    container.innerHTML = '<h1>Category not found</h1><p><a href="/">Home</a> | <a href="/categories/">Browse all categories</a></p>';
     StorefrontRuntime.loadCategories().then(cats => {
       const topCats = cats.filter(c => !c.parent);
       const wrap = document.createElement('div');
       topCats.forEach(cat => {
-        const a = document.createElement('a');
-        a.href = `/c/${cat.slug}/`;
-        a.textContent = cat.name;
-        a.className = 'me-2';
-        wrap.appendChild(a);
+        const a = document.createElement('a'); a.href = `/c/${cat.slug}/`; a.textContent = cat.name; a.className = 'me-2'; wrap.appendChild(a);
       });
       container.appendChild(wrap);
     });

--- a/assets/js/header-nav.js
+++ b/assets/js/header-nav.js
@@ -18,6 +18,14 @@ document.addEventListener('DOMContentLoaded', async () => {
           link.textContent = cat.name;
           menu.appendChild(link);
         });
+        const div = document.createElement('div');
+        div.className = 'dropdown-divider';
+        menu.appendChild(div);
+        const browse = document.createElement('a');
+        browse.className = 'dropdown-item';
+        browse.href = '/categories/';
+        browse.textContent = 'Browse all categories';
+        menu.appendChild(browse);
         navList.insertBefore(li, navList.firstChild ? navList.children[1] : null);
         const dd = bootstrap.Dropdown.getOrCreateInstance(toggle);
         toggle.addEventListener('keydown', e => {

--- a/assets/js/home-page.js
+++ b/assets/js/home-page.js
@@ -37,15 +37,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (wrap) {
         wrap.classList.remove('d-none');
         const view = document.getElementById('view-all-categories');
-        view.addEventListener('click', e => {
-          e.preventDefault();
-          const toggle = document.getElementById('shopDropdown');
-          if (toggle) {
-            const dd = bootstrap.Dropdown.getOrCreateInstance(toggle);
-            dd.show();
-            toggle.focus();
-          }
-        });
+        view.href = '/categories/';
       }
     }
   } catch (e) {

--- a/c/index.html
+++ b/c/index.html
@@ -38,19 +38,44 @@
   <section class="py-5">
     <div class="container">
       <div class="row">
-        <aside class="col-md-3 d-none d-md-block" id="category-sidebar"></aside>
+        <aside class="col-md-3 d-none d-md-block" id="category-sidebar">
+          <div id="filters-desktop"></div>
+          <div id="category-sidebar-list"></div>
+        </aside>
         <div class="col-md-9">
           <nav aria-label="Breadcrumb">
             <ol class="breadcrumb" id="breadcrumb"></ol>
           </nav>
           <h1 id="category-title"></h1>
           <div id="category-description"></div>
+          <div class="d-flex justify-content-between align-items-center mb-3">
+            <button class="btn btn-outline-primary d-md-none" id="open-filters" style="min-width:44px;min-height:44px;" aria-controls="filterDrawer">Filters</button>
+            <div class="ms-auto">
+              <label for="sort-select" class="me-2">Sort</label>
+              <select id="sort-select" class="form-select d-inline-block w-auto" style="min-width:150px;min-height:44px;"></select>
+            </div>
+          </div>
+          <div id="product-count" class="visually-hidden" aria-live="polite"></div>
           <div class="row" id="product-grid"></div>
           <nav class="mt-4" id="pagination"></nav>
         </div>
       </div>
     </div>
   </section>
+
+  <div class="offcanvas offcanvas-end" tabindex="-1" id="filterDrawer" aria-labelledby="filterDrawerLabel">
+    <div class="offcanvas-header">
+      <h5 id="filterDrawerLabel">Filters</h5>
+      <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    </div>
+    <div class="offcanvas-body">
+      <form id="filters-mobile"></form>
+    </div>
+    <div class="p-3 border-top d-flex justify-content-between">
+      <button class="btn btn-primary" id="apply-filters-mobile" style="min-width:44px;min-height:44px;">Apply</button>
+      <button class="btn btn-link" id="clear-filters-mobile" style="min-width:44px;min-height:44px;">Clear all</button>
+    </div>
+  </div>
 
   <footer class="py-4 mt-5">
     <div class="container text-center">

--- a/categories/index.html
+++ b/categories/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>All Categories | 4D Cosmetics</title>
+  <link rel="canonical" href="/categories/">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+  <link rel="stylesheet" href="/assets/css/custom.css">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-light bg-light">
+    <div class="container">
+      <a class="navbar-brand" href="/index.html">4D Cosmetics</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav ms-auto">
+          <li class="nav-item"><a class="nav-link" href="/index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="/products.html">Products</a></li>
+          <li class="nav-item"><a class="nav-link" href="/about.html">About</a></li>
+          <li class="nav-item"><a class="nav-link" href="/contact.html">Contact</a></li>
+          <li class="nav-item"><a class="nav-link" href="/cart.html">Cart (<span class="simpleCart_quantity">0</span>)</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <section class="py-5">
+    <div class="container">
+      <h1 class="mb-4">All Categories</h1>
+      <div class="row" id="all-categories"></div>
+    </div>
+  </section>
+
+  <footer class="py-4 mt-5">
+    <div class="container text-center">
+      <p class="mb-2">© 4D Cosmetics</p>
+      <a href="/privacy.html" class="me-3">Privacy Policy</a>
+      <a href="/terms.html">Terms</a>
+      <div class="mt-2">
+        <a href="#" class="text-dark me-2"><i class="fab fa-facebook"></i></a>
+        <a href="#" class="text-dark me-2"><i class="fab fa-twitter"></i></a>
+        <a href="#" class="text-dark"><i class="fab fa-instagram"></i></a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="/assets/js/jquery-2.2.4.min.js"></script>
+  <script src="/assets/js/bootstrap.bundle.min.js"></script>
+  <script src="/assets/js/simpleCart.min.js"></script>
+  <script src="/assets/js/simpleStore.js"></script>
+  <script src="/assets/js/config.js"></script>
+  <script src="/assets/js/storefront-runtime.js"></script>
+  <script src="/assets/js/header-nav.js"></script>
+  <script src="/assets/js/categories-page.js"></script>
+  <script src="/assets/js/diagnostics-overlay.js" defer></script>
+</body>
+</html>

--- a/scripts/tests/meta-jsonld-snapshots.js
+++ b/scripts/tests/meta-jsonld-snapshots.js
@@ -7,8 +7,14 @@ const root = path.join(__dirname, '..', '..');
 function startServer() {
   return new Promise(res => {
     const server = http.createServer((req, resp) => {
-      let filePath = path.join(root, req.url.split('?')[0]);
-      if (filePath.endsWith('/')) filePath += 'index.html';
+      const reqPath = req.url.split('?')[0];
+      let filePath = path.join(root, reqPath);
+      if (!fs.existsSync(filePath)) {
+        if (reqPath.startsWith('/c/')) filePath = path.join(root, 'c/index.html');
+        else if (reqPath.startsWith('/p/')) filePath = path.join(root, 'p/index.html');
+        else filePath = path.join(root, '404.html');
+      }
+      if (fs.statSync(filePath).isDirectory()) filePath = path.join(filePath, 'index.html');
       fs.readFile(filePath, (err, data) => {
         if (err) { resp.statusCode = 404; resp.end('Not found'); return; }
         const ext = path.extname(filePath).toLowerCase();
@@ -29,6 +35,7 @@ function startServer() {
   const page = await browser.newPage();
   const categories = JSON.parse(fs.readFileSync(path.join(root,'assets/data/categories.json'),'utf8'));
   const products = JSON.parse(fs.readFileSync(path.join(root,'assets/data/products.json'),'utf8'));
+  const catSlugs = new Set(categories.map(c=>c.slug));
   const report = [];
   let failed = false;
 
@@ -46,13 +53,13 @@ function startServer() {
   await page.goto(`http://localhost:${port}/c/${catWithImage.slug}/`,{waitUntil:'networkidle0'});
   let data = await page.evaluate(() => ({
     title: document.title,
-    canonical: document.querySelector('link[rel="canonical"]').href,
+    canonical: document.querySelector('link[rel="canonical"]')?.href || null,
     ogImage: document.querySelector('meta[property="og:image"]')?.content || null,
-    ld: document.getElementById('ld-json').textContent
+    ld: document.getElementById('ld-json')?.textContent || ''
   }));
   if (!data.ogImage) {failed=true; report.push('Category with image missing og:image');}
-  const ldCat = JSON.parse(data.ld);
-  if (ldCat['@type'] !== 'BreadcrumbList') {failed=true; report.push('Category breadcrumb missing');}
+  const ldCat = data.ld ? JSON.parse(data.ld) : null;
+  if (!ldCat || ldCat['@type'] !== 'BreadcrumbList') {failed=true; report.push('Category breadcrumb missing');}
   page.removeAllListeners('request');
   await page.setRequestInterception(false);
 
@@ -60,7 +67,7 @@ function startServer() {
   const catNoImage = categories[1];
   await page.goto(`http://localhost:${port}/c/${catNoImage.slug}/`,{waitUntil:'networkidle0'});
   data = await page.evaluate(() => ({
-    canonical: document.querySelector('link[rel="canonical"]').href,
+    canonical: document.querySelector('link[rel="canonical"]')?.href || null,
     ogImage: document.querySelector('meta[property="og:image"]')?.content || null
   }));
   if (data.ogImage) {failed=true; report.push('Category without image has og:image');}
@@ -70,9 +77,9 @@ function startServer() {
   await page.goto(`http://localhost:${port}/p/${prodWithImage.slug}`,{waitUntil:'networkidle0'});
   data = await page.evaluate(() => ({
     ogImage: document.querySelector('meta[property="og:image"]')?.content || null,
-    ld: document.getElementById('ld-json').textContent
+    ld: document.getElementById('ld-json')?.textContent || ''
   }));
-  const ldProd = JSON.parse(data.ld); // array
+  const ldProd = data.ld ? JSON.parse(data.ld) : [];
   const prodSchema = ldProd.find(i => i['@type']==='Product');
   if (!data.ogImage) {failed=true; report.push('Product with images missing og:image');}
   if (!prodSchema || !prodSchema.offers) {failed=true; report.push('Product schema missing offers');}
@@ -91,9 +98,45 @@ function startServer() {
     ogImage: document.querySelector('meta[property="og:image"]')?.content || null,
     ld: document.getElementById('ld-json').textContent
   }));
-  const ldProd2 = JSON.parse(data.ld); const prodSchema2 = ldProd2.find(i=>i['@type']==='Product');
+  const ldProd2 = data.ld ? JSON.parse(data.ld) : [];
+  const prodSchema2 = ldProd2.find(i=>i['@type']==='Product');
   if (data.ogImage) {failed=true; report.push('Product without images has og:image');}
-  if (prodSchema2.image) {failed=true; report.push('Product schema unexpectedly has image');}
+  if (prodSchema2 && prodSchema2.image) {failed=true; report.push('Product schema unexpectedly has image');}
+
+  // filtered category snapshot
+  const filteredUrl = `http://localhost:${port}/c/${categories[0].slug}/?brand=${encodeURIComponent(products[0].brand)}&inStock=true&priceMin=10&sort=price_desc&page=2`;
+  await page.goto(filteredUrl,{waitUntil:'networkidle0'});
+  data = await page.evaluate(() => ({
+    canonical: document.querySelector('link[rel="canonical"]').href,
+    total: document.getElementById('product-grid').dataset.total,
+    gridCount: document.querySelectorAll('#product-grid > div').length,
+    empty: document.getElementById('product-grid').textContent.includes('No products match your filters.'),
+    pages: document.querySelectorAll('#pagination .page-item').length
+  }));
+  if (data.canonical.includes('?')) {failed=true; report.push('Filtered category canonical has query params');}
+  if (!data.empty && data.gridCount === 0) {failed=true; report.push('Filtered category missing grid');}
+  const expectedPages = Math.ceil((parseInt(data.total,10)||0)/12);
+  if ((expectedPages<=1 && data.pages!==0) || (expectedPages>1 && data.pages!==(expectedPages+2))) {
+    failed=true; report.push('Filtered category pagination mismatch');
+  }
+
+  // deep-link test
+  const deepLinkUrl = `http://localhost:${port}/c/${categories[0].slug}/?brand=${encodeURIComponent(products[0].brand)}`;
+  await page.goto(deepLinkUrl,{waitUntil:'networkidle0'});
+  const deepChecked = await page.evaluate((brand)=>{
+    const cb = document.querySelector(`input[name="brand"][value="${brand}"]`);
+    return cb ? cb.checked : false;
+  }, products[0].brand);
+  if (!deepChecked) {failed=true; report.push('Deep-link filter not pre-selected');}
+
+  // categories page link crawl
+  await page.goto(`http://localhost:${port}/categories/`,{waitUntil:'networkidle0'});
+  const links = await page.$$eval('#all-categories > div > a', els => els.map(a => a.getAttribute('href')));
+  if (links.length !== categories.filter(c=>!c.parent).length) {failed=true; report.push('Categories page tile count mismatch');}
+  links.forEach(href => {
+    const slug = href.split('/')[2];
+    if (!catSlugs.has(slug)) {failed=true; report.push(`Categories page has invalid link ${href}`);}
+  });
 
   await browser.close();
   server.close();

--- a/scripts/tests/sitemap-guard.js
+++ b/scripts/tests/sitemap-guard.js
@@ -10,6 +10,7 @@ const categories = readJSON('assets/data/categories.json', []);
 const products = readJSON('assets/data/products.json', []);
 const exclude = new Set(readJSON('assets/data/sitemap-exclude.json', []));
 const expected = new Set();
+expected.add('/categories/');
 categories.forEach(c=>{ const p = `/c/${c.slug}/`; if(!exclude.has(p)) expected.add(p); });
 products.forEach(p=>{ const u = `/p/${p.slug}`; if(!exclude.has(u)) expected.add(u); });
 

--- a/scripts/tests/spa-fallback.js
+++ b/scripts/tests/spa-fallback.js
@@ -7,8 +7,14 @@ const root = path.join(__dirname, '..', '..');
 function startServer() {
   return new Promise(res => {
     const server = http.createServer((req, resp) => {
-      let filePath = path.join(root, req.url.split('?')[0]);
-      if (filePath.endsWith('/')) filePath += 'index.html';
+      const reqPath = req.url.split('?')[0];
+      let filePath = path.join(root, reqPath);
+      if (!fs.existsSync(filePath)) {
+        if (reqPath.startsWith('/c/')) filePath = path.join(root, 'c/index.html');
+        else if (reqPath.startsWith('/p/')) filePath = path.join(root, 'p/index.html');
+        else filePath = path.join(root, '404.html');
+      }
+      if (fs.statSync(filePath).isDirectory()) filePath = path.join(filePath, 'index.html');
       fs.readFile(filePath, (err, data) => {
         if (err) { resp.statusCode=404; resp.end('Not found'); return; }
         const ext = path.extname(filePath).toLowerCase();

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://4dcosmetics.com/</loc></url>
+  <url><loc>https://4dcosmetics.com/categories/</loc></url>
   <url><loc>https://4dcosmetics.com/c/makeup/</loc></url>
   <url><loc>https://4dcosmetics.com/c/skin-care/</loc></url>
   <url><loc>https://4dcosmetics.com/c/fragrance/</loc></url>


### PR DESCRIPTION
## Summary
- add client-side sorting and filtering with URL sync to category pages
- introduce mobile filter drawer and live product counts with pagination reset
- create `/categories/` browse page and link it site-wide

## Testing
- `npm run validate:data`
- `npm run lint:static`
- `npm run test:meta`
- `npm run test:sitemap`
- `npm run test:spa`
- `npm run test:lighthouse` *(fails: CHROME_PATH environment variable must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68a48ade58188320b931e0c29e646ed1