### PR TITLE
feat: add client-side search and recent views

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ or manually install using the latest [release](https://github.com/chrisdiana/sim
   - Ensure the URL is listed in `sitemap.xml`.
   - New top-level categories automatically appear in the homepage tiles and the header “Shop” menu, and all pages emit correct canonical, Open Graph, and JSON-LD metadata.
 
+## Search & Discovery
+
+- Queries are plain space-separated tokens matched case-insensitively against product name, brand, categories, tags, and short descriptions.
+- Ranking weight order: name prefix, name token, brand, category/tag, then short description.
+- Optional fields in `products.json`:
+  - `createdAt` (ISO 8601) enables a **New** badge when within 30 days.
+  - `stockLevel` (integer) triggers **Low stock** when `1–5` and `inStock` is true.
+- Badge priority (left→right): Out of stock, Low stock, New, Bestseller (`tags` includes `"bestseller"`).
+- Recently viewed products are stored in `localStorage` under `recently_viewed` (up to 8 slugs).
+- The `/search/` route is client-rendered and contains `<meta name="robots" content="noindex, follow">` with no canonical tag.
+
 # Using Plugins
 
 To use a plugin, add a reference just before your `config.js` file

--- a/assets/js/category-page.js
+++ b/assets/js/category-page.js
@@ -318,7 +318,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       } else {
         pageItems.forEach(prod => {
           const col = document.createElement('div'); col.className='col-6 col-md-4 col-lg-3 mb-4';
-          col.innerHTML = `<a href="/p/${prod.slug}" class="text-decoration-none text-dark" style="display:block;min-width:44px;min-height:44px;"><div class="card h-100"><img src="${prod.images[0]}" class="card-img-top" alt="${prod.name}" loading="lazy" width="300" height="300" style="object-fit:cover;aspect-ratio:1/1;"><div class="card-body p-2"><h6 class="card-title">${prod.name}</h6><p class="card-text mb-1">${StorefrontRuntime.formatPrice(prod.price, prod.currency)}</p>${prod.inStock ? '' : '<span class="badge bg-secondary">Out of stock</span>'}</div></div></a>`;
+          col.innerHTML = `<a href="/p/${prod.slug}" class="text-decoration-none text-dark" style="display:block;min-width:44px;min-height:44px;"><div class="card h-100"><img src="${prod.images[0]}" class="card-img-top" alt="${prod.name}" loading="lazy" width="300" height="300" style="object-fit:cover;aspect-ratio:1/1;"><div class="card-body p-2"><div class="mb-1">${StorefrontRuntime.renderProductBadgesHTML(prod)}</div><h6 class="card-title">${prod.name}</h6><p class="card-text mb-1">${StorefrontRuntime.formatPrice(prod.price, prod.currency)}</p></div></div></a>`;
           grid.appendChild(col);
         });
       }

--- a/assets/js/header-nav.js
+++ b/assets/js/header-nav.js
@@ -1,5 +1,18 @@
+async function ensureSearchEngine() {
+  if (window.SearchEngine) return;
+  await new Promise(res => {
+    const s = document.createElement('script');
+    s.src = '/assets/js/search.js';
+    s.onload = res;
+    document.head.appendChild(s);
+  });
+}
+
+function debounce(fn, delay){ let t; return (...args)=>{ clearTimeout(t); t=setTimeout(()=>fn(...args),delay); }; }
+
 document.addEventListener('DOMContentLoaded', async () => {
   try {
+    await ensureSearchEngine();
     const categories = await StorefrontRuntime.loadCategories();
     const topCats = categories.filter(c => !c.parent)
       .sort((a, b) => (a.sortOrder - b.sortOrder) || a.name.localeCompare(b.name));
@@ -61,6 +74,78 @@ document.addEventListener('DOMContentLoaded', async () => {
           li.querySelector('#shopDropdown').classList.add('active');
         }
       }
+    }
+
+    const collapse = document.getElementById('navbarNav');
+    if (collapse) {
+      const form = document.createElement('form');
+      form.className = 'd-flex ms-lg-3 position-relative';
+      form.setAttribute('role', 'search');
+      form.addEventListener('submit', e => {
+        e.preventDefault();
+        const q = input.value.trim();
+        if (q) window.location.href = `/search/?q=${encodeURIComponent(q)}`;
+      });
+      const input = document.createElement('input');
+      input.type = 'search';
+      input.className = 'form-control';
+      input.placeholder = 'Search products';
+      input.id = 'header-search';
+      input.autocomplete = 'off';
+      input.setAttribute('aria-label', 'Search products');
+      input.setAttribute('aria-expanded', 'false');
+      form.appendChild(input);
+      const panel = document.createElement('div');
+      panel.id = 'search-autocomplete';
+      panel.className = 'list-group position-absolute top-100 start-0 w-100 d-none';
+      panel.setAttribute('role', 'listbox');
+      form.appendChild(panel);
+      collapse.appendChild(form);
+
+      let activeIndex = -1;
+      function hidePanel(){ panel.classList.add('d-none'); input.setAttribute('aria-expanded','false'); input.removeAttribute('aria-activedescendant'); activeIndex=-1; }
+      function setActive(){ Array.from(panel.children).forEach((el,i)=>{ if(i===activeIndex){ el.classList.add('active'); input.setAttribute('aria-activedescendant', el.id);} else el.classList.remove('active'); }); }
+      const update = debounce(async () => {
+        const q = input.value.trim();
+        if (!q){ hidePanel(); return; }
+        const results = await SearchEngine.search(q);
+        panel.innerHTML='';
+        activeIndex=-1;
+        if (results.length) {
+          results.slice(0,8).forEach((prod,i)=>{
+            const a=document.createElement('a');
+            a.href=`/p/${prod.slug}`;
+            a.className='list-group-item list-group-item-action d-flex align-items-center';
+            a.setAttribute('role','option');
+            a.id=`ac-item-${i}`;
+            const img=document.createElement('img'); img.src=prod.images[0]; img.alt=''; img.width=40; img.height=40; img.loading='lazy'; img.className='me-2'; a.appendChild(img);
+            const span=document.createElement('span'); span.textContent=prod.name; a.appendChild(span);
+            if(prod.brand){ const b=document.createElement('small'); b.className='text-muted ms-1'; b.textContent=prod.brand; a.appendChild(b); }
+            const price=document.createElement('span'); price.className='ms-auto'; price.textContent=StorefrontRuntime.formatPrice(prod.price, prod.currency); a.appendChild(price);
+            panel.appendChild(a);
+          });
+          const view=document.createElement('a'); view.href=`/search/?q=${encodeURIComponent(q)}`; view.className='list-group-item list-group-item-action'; view.textContent=`View all results for "${q}"`; panel.appendChild(view);
+        } else {
+          const div=document.createElement('div'); div.className='list-group-item'; div.textContent='No matches. Press Enter to search all results.'; panel.appendChild(div);
+        }
+        panel.classList.remove('d-none');
+        input.setAttribute('aria-expanded','true');
+      },150);
+
+      input.addEventListener('input', update);
+      input.addEventListener('focus', update);
+      input.addEventListener('keydown', e => {
+        if (e.key === 'ArrowDown' && !panel.classList.contains('d-none')) { e.preventDefault(); activeIndex=(activeIndex+1)%panel.children.length; setActive(); }
+        else if (e.key === 'ArrowUp' && !panel.classList.contains('d-none')) { e.preventDefault(); activeIndex=(activeIndex-1+panel.children.length)%panel.children.length; setActive(); }
+        else if (e.key === 'Enter') {
+          if (!panel.classList.contains('d-none') && activeIndex>=0) {
+            const el=panel.children[activeIndex]; const href=el.getAttribute('href'); if(href) window.location.href=href; else window.location.href=`/search/?q=${encodeURIComponent(input.value.trim())}`;
+          } else if (input.value.trim()) {
+            window.location.href=`/search/?q=${encodeURIComponent(input.value.trim())}`;
+          }
+        } else if (e.key === 'Escape') { hidePanel(); }
+      });
+      document.addEventListener('click', e => { if(!form.contains(e.target)) hidePanel(); });
     }
 
     const footerContainer = document.querySelector('footer .container');

--- a/assets/js/home-page.js
+++ b/assets/js/home-page.js
@@ -3,6 +3,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   if (!container) return;
   try {
     const categories = await StorefrontRuntime.loadCategories();
+    await StorefrontRuntime.loadProducts();
     const topCats = categories.filter(c => !c.parent)
       .sort((a,b)=>(a.sortOrder - b.sortOrder) || a.name.localeCompare(b.name));
     const limit = 6;
@@ -39,6 +40,19 @@ document.addEventListener('DOMContentLoaded', async () => {
         const view = document.getElementById('view-all-categories');
         view.href = '/categories/';
       }
+    }
+
+    const recentSection = document.getElementById('recently-viewed-home');
+    const recentRow = document.getElementById('recently-viewed-home-row');
+    const recSlugs = StorefrontRuntime.getRecentlyViewed();
+    const prods = recSlugs.map(StorefrontRuntime.getProductBySlug).filter(Boolean);
+    if (prods.length >= 3) {
+      recentSection.classList.remove('d-none');
+      prods.forEach(p => {
+        const col=document.createElement('div'); col.className='col-6 col-md-3 mb-4';
+        col.innerHTML = `<a href="/p/${p.slug}" class="text-decoration-none text-dark" style="display:block;min-width:44px;min-height:44px;"><div class="card h-100"><img src="${p.images[0]}" class="card-img-top" alt="${p.name}" loading="lazy" width="300" height="300" style="object-fit:cover;aspect-ratio:1/1;"><div class="card-body p-2"><div class="mb-1">${StorefrontRuntime.renderProductBadgesHTML(p)}</div><h6 class="card-title">${p.name}</h6><p class="card-text mb-1">${StorefrontRuntime.formatPrice(p.price, p.currency)}</p></div></div></a>`;
+        recentRow.appendChild(col);
+      });
     }
   } catch (e) {
     console.error(e);

--- a/assets/js/product-page.js
+++ b/assets/js/product-page.js
@@ -29,6 +29,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
 
       document.getElementById('product-title').textContent = product.name;
+      document.getElementById('product-badges').innerHTML = StorefrontRuntime.renderProductBadgesHTML(product);
       document.getElementById('product-price').textContent = StorefrontRuntime.formatPrice(product.price, product.currency);
       document.getElementById('stock-status').textContent = product.inStock ? 'In stock' : 'Out of stock';
       document.getElementById('short-description').textContent = product.shortDescription || '';
@@ -112,6 +113,20 @@ document.addEventListener('DOMContentLoaded', async () => {
           });
           thumbs.appendChild(t);
         });
+      }
+
+      StorefrontRuntime.addRecentlyViewed(product.slug);
+      const recent = StorefrontRuntime.getRecentlyViewed().filter(s=>s!==product.slug);
+      const prods = recent.map(StorefrontRuntime.getProductBySlug).filter(Boolean);
+      if (prods.length >= 4){
+        const sec = document.getElementById('recently-viewed-section');
+        const row = document.getElementById('recently-viewed');
+        prods.forEach(p => {
+          const col=document.createElement('div'); col.className='col-6 col-md-3 mb-4';
+          col.innerHTML = `<a href="/p/${p.slug}" class="text-decoration-none text-dark" style="display:block;min-width:44px;min-height:44px;"><div class="card h-100"><img src="${p.images[0]}" class="card-img-top" alt="${p.name}" loading="lazy" width="300" height="300" style="object-fit:cover;aspect-ratio:1/1;"><div class="card-body p-2"><div class="mb-1">${StorefrontRuntime.renderProductBadgesHTML(p)}</div><h6 class="card-title">${p.name}</h6><p class="card-text mb-1">${StorefrontRuntime.formatPrice(p.price, p.currency)}</p></div></div></a>`;
+          row.appendChild(col);
+        });
+        sec.classList.remove('d-none');
       }
   } catch (e) {
     console.error(e);

--- a/assets/js/search-page.js
+++ b/assets/js/search-page.js
@@ -1,0 +1,95 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const params = new URLSearchParams(window.location.search);
+  const query = (params.get('q') || '').trim();
+  const heading = document.getElementById('search-heading');
+  const countEl = document.getElementById('results-count');
+  const empty = document.getElementById('search-empty');
+  const emptyQuery = document.getElementById('empty-query');
+  const emptyLinks = document.getElementById('empty-links');
+  const grid = document.getElementById('search-grid');
+  const sortSel = document.getElementById('sort');
+  const perPage = 12;
+  let sort = params.get('sort') || 'featured';
+  let page = parseInt(params.get('page') || '1',10);
+  if (!query) { heading.textContent = 'Search'; return; }
+  heading.textContent = `Search results for "${query}"`;
+  sortSel.value = sort;
+  await StorefrontRuntime.loadProducts();
+  await StorefrontRuntime.loadCategories();
+  let results = await SearchEngine.search(query);
+
+  function sortProducts(arr){
+    const a=[...arr];
+    switch(sort){
+      case 'price_asc': return a.sort((x,y)=>x.price-y.price);
+      case 'price_desc': return a.sort((x,y)=>y.price-x.price);
+      case 'name_asc': return a.sort((x,y)=>x.name.localeCompare(y.name));
+      case 'newest': return a.sort((x,y)=>{
+        const dx = x.createdAt ? Date.parse(x.createdAt) : x.id;
+        const dy = y.createdAt ? Date.parse(y.createdAt) : y.id;
+        return dy-dx;
+      });
+      default: return a;
+    }
+  }
+
+  function render(){
+    let items = sortProducts(results);
+    const total = items.length;
+    const totalPages = Math.ceil(total/perPage)||1;
+    if (page>totalPages) page=totalPages;
+    const pageItems = StorefrontRuntime.paginateArray(items,page,perPage);
+    grid.innerHTML='';
+    if (!pageItems.length){
+      empty.classList.remove('d-none');
+      emptyQuery.textContent = query;
+      countEl.textContent = '0 results';
+    } else {
+      empty.classList.add('d-none');
+      pageItems.forEach(prod=>{
+        const col=document.createElement('div'); col.className='col-6 col-md-4 col-lg-3 mb-4';
+        col.innerHTML = `<a href="/p/${prod.slug}" class="text-decoration-none text-dark" style="display:block;min-width:44px;min-height:44px;"><div class="card h-100"><img src="${prod.images[0]}" class="card-img-top" alt="${prod.name}" loading="lazy" width="300" height="300" style="object-fit:cover;aspect-ratio:1/1;"><div class="card-body p-2"><div class="mb-1">${StorefrontRuntime.renderProductBadgesHTML(prod)}</div><h6 class="card-title">${prod.name}</h6><p class="card-text mb-1">${StorefrontRuntime.formatPrice(prod.price, prod.currency)}</p></div></div></a>`;
+        grid.appendChild(col);
+      });
+      countEl.textContent = `${total} results`;
+    }
+    const nav = document.getElementById('pagination'); nav.innerHTML='';
+    if (total>perPage){
+      const totalPages = Math.ceil(total/perPage);
+      const ul=document.createElement('ul'); ul.className='pagination';
+      const prev=document.createElement('li'); const prevA=document.createElement('a'); prevA.className='page-link'; prevA.textContent='Previous'; prevA.style.minWidth='44px'; prevA.style.minHeight='44px';
+      if (page===1){ prev.className='page-item disabled'; prevA.setAttribute('aria-disabled','true'); prevA.tabIndex=-1; } else { prev.className='page-item'; prevA.href=buildURL({page:page-1}); }
+      prev.appendChild(prevA); ul.appendChild(prev);
+      for(let i=1;i<=totalPages;i++){ const li=document.createElement('li'); li.className='page-item'+(i===page?' active':''); const a=document.createElement('a'); a.className='page-link'; a.textContent=i; a.style.minWidth='44px'; a.style.minHeight='44px'; if(i!==page) a.href=buildURL({page:i}); li.appendChild(a); ul.appendChild(li); }
+      const next=document.createElement('li'); const nextA=document.createElement('a'); nextA.className='page-link'; nextA.textContent='Next'; nextA.style.minWidth='44px'; nextA.style.minHeight='44px';
+      if (page===totalPages){ next.className='page-item disabled'; nextA.setAttribute('aria-disabled','true'); nextA.tabIndex=-1; } else { next.className='page-item'; nextA.href=buildURL({page:page+1}); }
+      next.appendChild(nextA); ul.appendChild(next); nav.appendChild(ul);
+    }
+  }
+
+  function buildURL(extra){
+    const p=new URLSearchParams();
+    p.set('q', query);
+    const s=extra.sort||sort; if(s && s!=='featured') p.set('sort', s);
+    const pg=extra.page||page; if(pg && pg>1) p.set('page', pg);
+    return `?${p.toString()}`;
+  }
+
+  sortSel.addEventListener('change', () => {
+    sort = sortSel.value; page=1; window.history.replaceState({},'',buildURL({})); render();
+  });
+
+  render();
+
+  if (emptyLinks){
+    const cats = await StorefrontRuntime.loadCategories();
+    const topCats = cats.filter(c=>!c.parent).slice(0,4);
+    topCats.forEach(c=>{
+      const a=document.createElement('a');
+      a.href=`/c/${c.slug}/`;
+      a.textContent=c.name;
+      a.className='me-2';
+      emptyLinks.appendChild(a);
+    });
+  }
+});

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,0 +1,52 @@
+const SearchEngine = (() => {
+  let initialized = false;
+  let products = [];
+  let categories = [];
+  const catMap = {};
+
+  function tokenize(q){
+    return q.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  }
+
+  async function init(){
+    if (initialized) return;
+    products = await StorefrontRuntime.loadProducts();
+    categories = await StorefrontRuntime.loadCategories();
+    categories.forEach(c=>{catMap[c.slug]=c.name.toLowerCase();});
+    initialized = true;
+  }
+
+  function matchProduct(prod, tokens){
+    const name = prod.name.toLowerCase();
+    const brand = (prod.brand||'').toLowerCase();
+    const tags = (prod.tags||[]).map(t=>t.toLowerCase());
+    const cats = (prod.categories||[]).map(slug=>catMap[slug]||slug);
+    const short = (prod.shortDescription||'').toLowerCase();
+    let score = 0;
+    let nameOrBrandMatched = false;
+    for(const t of tokens){
+      if(name.startsWith(t)){ score+=50; nameOrBrandMatched=true; }
+      else if(name.includes(t)){ score+=40; nameOrBrandMatched=true; }
+      if(brand.includes(t)){ score+=30; nameOrBrandMatched=true; }
+      if(cats.some(c=>c.includes(t)) || tags.some(tag=>tag.includes(t))){ score+=20; }
+      if(short.includes(t)) score+=10;
+    }
+    if(tokens.length>=2 && !nameOrBrandMatched) return 0;
+    return score;
+  }
+
+  async function search(query){
+    await init();
+    const tokens = tokenize(query);
+    if(!tokens.length) return [];
+    const results = [];
+    products.forEach(p=>{
+      const s = matchProduct(p, tokens);
+      if(s>0) results.push({product:p, score:s});
+    });
+    results.sort((a,b)=>b.score - a.score);
+    return results.map(r=>r.product);
+  }
+
+  return { search, tokenize };
+})();

--- a/assets/js/storefront-runtime.js
+++ b/assets/js/storefront-runtime.js
@@ -1,6 +1,7 @@
 const StorefrontRuntime = (() => {
   let productsCache = null;
   let categoriesCache = null;
+  const RECENT_KEY = 'recently_viewed';
 
   async function loadProducts() {
     if (productsCache) return productsCache;
@@ -69,6 +70,52 @@ const StorefrontRuntime = (() => {
     (events[event] || []).forEach(cb => cb(data));
   }
 
+  function getRecentlyViewed() {
+    try {
+      const arr = JSON.parse(localStorage.getItem(RECENT_KEY) || '[]');
+      const list = Array.isArray(arr) ? arr : [];
+      if (productsCache) {
+        return list.filter(slug => productsCache.some(p => p.slug === slug));
+      }
+      return list;
+    } catch {
+      return [];
+    }
+  }
+
+  function addRecentlyViewed(slug) {
+    const list = getRecentlyViewed().filter(s => s !== slug);
+    list.unshift(slug);
+    if (list.length > 8) list.length = 8;
+    try {
+      localStorage.setItem(RECENT_KEY, JSON.stringify(list));
+    } catch {}
+  }
+
+  function getProductBadges(prod) {
+    const badges = [];
+    const now = Date.now();
+    if (prod.inStock === false) {
+      badges.push({label: 'Out of stock', cls: 'bg-secondary'});
+    } else if (typeof prod.stockLevel === 'number' && prod.stockLevel > 0 && prod.stockLevel <= 5) {
+      badges.push({label: 'Low stock', cls: 'bg-warning text-dark'});
+    }
+    if (prod.createdAt) {
+      const created = Date.parse(prod.createdAt);
+      if (!isNaN(created) && (now - created) <= 30*24*60*60*1000) {
+        badges.push({label: 'New', cls: 'bg-success'});
+      }
+    }
+    if (Array.isArray(prod.tags) && prod.tags.includes('bestseller')) {
+      badges.push({label: 'Bestseller', cls: 'bg-info text-dark'});
+    }
+    return badges;
+  }
+
+  function renderProductBadgesHTML(prod) {
+    return getProductBadges(prod).map(b => `<span class="badge ${b.cls} me-1" aria-label="${b.label}">${b.label}</span>`).join('');
+  }
+
   return {
     loadProducts,
     loadCategories,
@@ -80,6 +127,11 @@ const StorefrontRuntime = (() => {
     getQueryParam,
     setQueryParam,
     on,
-    emit
+    emit,
+    getRecentlyViewed,
+    addRecentlyViewed,
+    getProductBadges,
+    renderProductBadgesHTML,
+    RECENT_KEY
   };
 })();

--- a/index.html
+++ b/index.html
@@ -39,12 +39,19 @@
     <section class="py-5 bg-light">
       <div class="container">
         <h2 class="mb-4 text-center">Shop by Category</h2>
-        <div class="row" id="home-categories"></div>
-        <div class="text-center d-none" id="view-all-categories-wrapper">
-          <a href="#" id="view-all-categories">View all categories</a>
-        </div>
+      <div class="row" id="home-categories"></div>
+      <div class="text-center d-none" id="view-all-categories-wrapper">
+        <a href="#" id="view-all-categories">View all categories</a>
       </div>
-    </section>
+    </div>
+  </section>
+
+  <section class="py-5 d-none" id="recently-viewed-home">
+    <div class="container">
+      <h2 class="mb-4 text-center">Recently viewed</h2>
+      <div class="row" id="recently-viewed-home-row"></div>
+    </div>
+  </section>
 
   <section class="py-5">
     <div class="container">

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test:meta": "node scripts/tests/meta-jsonld-snapshots.js",
     "test:sitemap": "node scripts/tests/sitemap-guard.js",
     "test:spa": "node scripts/tests/spa-fallback.js",
-    "test:lighthouse": "node scripts/tests/lighthouse-budgets.js"
+    "test:lighthouse": "node scripts/tests/lighthouse-budgets.js",
+    "test:features": "node scripts/tests/features.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/tests/features.js
+++ b/scripts/tests/features.js
@@ -1,0 +1,98 @@
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const puppeteer = require('puppeteer');
+
+const root = path.join(__dirname, '..', '..');
+function startServer(){
+  return new Promise(res=>{
+    const server = http.createServer((req, resp)=>{
+      const reqPath = req.url.split('?')[0];
+      let filePath = path.join(root, reqPath);
+      if (!fs.existsSync(filePath)) {
+        if (reqPath.startsWith('/c/')) filePath = path.join(root,'c/index.html');
+        else if (reqPath.startsWith('/p/')) filePath = path.join(root,'p/index.html');
+        else filePath = path.join(root,'404.html');
+      }
+      if (fs.statSync(filePath).isDirectory()) filePath = path.join(filePath,'index.html');
+      fs.readFile(filePath,(err,data)=>{
+        if(err){ resp.statusCode=404; resp.end('not found'); return; }
+        const ext = path.extname(filePath).toLowerCase();
+        const type = ext==='.html'?'text/html':ext==='.js'?'application/javascript':ext==='.json'?'application/json':undefined;
+        if(type) resp.setHeader('Content-Type', type);
+        resp.end(data);
+      });
+    }).listen(0,()=>{ const {port}=server.address(); res({server,port}); });
+  });
+}
+
+(async()=>{
+  const {server, port} = await startServer();
+  const browser = await puppeteer.launch({args:['--no-sandbox']});
+  const page = await browser.newPage();
+  const products = JSON.parse(fs.readFileSync(path.join(root,'assets/data/products.json'),'utf8'));
+  const first = products[0];
+  const second = products[1];
+  const brand = first.brand || 'test';
+  const report = [];
+  let failed = false;
+
+  // search snapshots
+  await page.goto(`http://localhost:${port}/search/?q=${encodeURIComponent(brand)}`,{waitUntil:'networkidle0'});
+  let data = await page.evaluate(()=>({
+    h1: document.getElementById('search-heading')?.textContent || '',
+    cards: document.querySelectorAll('#search-grid .card').length,
+    canonical: document.querySelector('link[rel="canonical"]')?.href || null,
+    robots: document.querySelector('meta[name="robots"]')?.content || null
+  }));
+  if (!data.h1.includes(brand)) {failed=true; report.push('Search heading missing brand');}
+  if (data.cards < 1) {failed=true; report.push('Search results missing cards');}
+  if (data.canonical) {failed=true; report.push('Search page should not have canonical');}
+  if (data.robots !== 'noindex, follow') {failed=true; report.push('Search page robots tag incorrect');}
+
+  await page.goto(`http://localhost:${port}/search/?q=nonsense`,{waitUntil:'networkidle0'});
+  data = await page.evaluate(()=>({
+    empty: document.getElementById('search-empty')?.textContent || '',
+    status: document.title
+  }));
+  if (!/No products found/i.test(data.empty)) {failed=true; report.push('Search empty state missing');}
+
+  // autocomplete smoke
+  await page.goto(`http://localhost:${port}/`,{waitUntil:'networkidle0'});
+  await page.waitForSelector('#header-search');
+  await page.waitForTimeout(500);
+  await page.focus('#header-search');
+  const prefix = first.name.slice(0,3);
+  await page.type('#header-search', prefix);
+  await page.waitForSelector('#search-autocomplete:not(.d-none)',{timeout:10000});
+  const sugg = await page.$$eval('#search-autocomplete a', els => els.length);
+  if (sugg < 1) {failed=true; report.push('Autocomplete suggestions missing');}
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('Enter');
+  await page.waitForNavigation({waitUntil:'networkidle0'});
+  const title = await page.$eval('#product-title', el=>el.textContent);
+  if (!title.includes(first.name)) {failed=true; report.push('Autocomplete navigation failed');}
+
+  // recently viewed
+  await page.goto(`http://localhost:${port}/p/${first.slug}`,{waitUntil:'networkidle0'});
+  await page.goto(`http://localhost:${port}/p/${second.slug}`,{waitUntil:'networkidle0'});
+  await page.goto(`http://localhost:${port}/`,{waitUntil:'networkidle0'});
+  const recentCount = await page.evaluate(()=>{
+    const sec=document.getElementById('recently-viewed-home');
+    const items=document.querySelectorAll('#recently-viewed-home-row .card').length;
+    return sec && !sec.classList.contains('d-none') ? items : 0;
+  });
+  if (recentCount < 2) {failed=true; report.push('Recently viewed section missing');}
+
+  // badges
+  await page.goto(`http://localhost:${port}/search/?q=blossom`,{waitUntil:'networkidle0'});
+  const hasBadge = await page.evaluate(()=>Array.from(document.querySelectorAll('#search-grid .badge')).some(b=>/Out of stock/i.test(b.textContent)));
+  if (!hasBadge) {failed=true; report.push('Out of stock badge missing');}
+
+  await browser.close();
+  server.close();
+  if (!report.length) report.push('All feature checks passed');
+  fs.writeFileSync(path.join(root,'feature-report.txt'), report.join('\n'));
+  console.log(report.join('\n'));
+  if (failed) process.exit(1);
+})();

--- a/search/index.html
+++ b/search/index.html
@@ -1,16 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Product | 4D Cosmetics</title>
-    <meta name="description" content="">
-    <link rel="canonical" id="canonical-link" href="">
-    <meta property="og:title" content="" id="og-title">
-    <meta property="og:description" content="" id="og-description">
-    <meta property="og:url" content="" id="og-url">
-    <meta property="og:image" content="" id="og-image">
-    <script type="application/ld+json" id="ld-json"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Search | 4D Cosmetics</title>
+  <meta name="robots" content="noindex, follow">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
@@ -37,32 +31,24 @@
 
   <section class="py-5">
     <div class="container">
-      <nav aria-label="Breadcrumb">
-        <ol class="breadcrumb" id="breadcrumb"></ol>
-      </nav>
-      <a href="#" id="back-link" class="d-block mb-3">&laquo; Back</a>
-      <div class="row">
-        <div class="col-md-6">
-            <img id="main-image" class="img-fluid" alt="" style="object-fit:cover;aspect-ratio:1/1;" width="600" height="600">
-          <div class="mt-2" id="image-thumbs"></div>
-        </div>
-        <div class="col-md-6">
-          <h1 id="product-title"></h1>
-          <div id="product-badges" class="mb-2"></div>
-          <p id="product-price" class="h4"></p>
-          <p id="stock-status"></p>
-          <p id="short-description"></p>
-          <div id="category-badges" class="mb-3"></div>
-          <section id="details"></section>
-        </div>
+      <h1 class="mb-3" id="search-heading"></h1>
+      <p id="results-count" aria-live="polite"></p>
+      <div class="mb-3">
+        <label for="sort" class="visually-hidden">Sort</label>
+        <select id="sort" class="form-select w-auto">
+          <option value="featured">Featured</option>
+          <option value="price_asc">Price: Low to High</option>
+          <option value="price_desc">Price: High to Low</option>
+          <option value="name_asc">Name A-Z</option>
+          <option value="newest">Newest</option>
+        </select>
       </div>
-    </div>
-  </section>
-
-  <section class="py-5 d-none" id="recently-viewed-section">
-    <div class="container">
-      <h2 class="mb-4">Recently viewed</h2>
-      <div id="recently-viewed" class="row"></div>
+      <div id="search-grid" class="row"></div>
+      <div id="search-empty" class="d-none">
+        <p>No products found for “<span id="empty-query"></span>”.</p>
+        <div id="empty-links"></div>
+      </div>
+      <nav id="pagination" class="mt-3"></nav>
     </div>
   </section>
 
@@ -86,7 +72,8 @@
   <script src="/assets/js/config.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/header-nav.js"></script>
-  <script src="/assets/js/product-page.js"></script>
+  <script src="/assets/js/search.js"></script>
+  <script src="/assets/js/search-page.js"></script>
   <script src="/assets/js/diagnostics-overlay.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add in-memory search engine with header autocomplete and /search/ page
- show product badges and recently viewed sections on home and product pages
- cover search, badges, and recent views with basic smoke tests

## Testing
- `npm run validate:data`
- `npm run lint:static`
- `npm run test:meta`
- `npm run test:sitemap`
- `npm run test:spa`
- `npm run test:lighthouse` *(fails: CHROME_PATH environment variable must be set to a Chrome/Chromium executable no older than Chrome stable)*
- `npm run test:features` *(fails: Waiting for selector `#search-autocomplete:not(.d-none)` failed: Waiting failed: 10000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68a4942f11108320928722474ee41812