### PR TITLE
Add simpleCart markup to category and product pages

### DIFF
--- a/assets/js/category-page.js
+++ b/assets/js/category-page.js
@@ -317,8 +317,20 @@ document.addEventListener('DOMContentLoaded', async () => {
         grid.appendChild(p); grid.appendChild(link);
       } else {
         pageItems.forEach(prod => {
-          const col = document.createElement('div'); col.className='col-6 col-md-4 col-lg-3 mb-4';
-          col.innerHTML = `<a href="/p/${prod.slug}" class="text-decoration-none text-dark" style="display:block;min-width:44px;min-height:44px;"><div class="card h-100"><img src="${prod.images[0]}" class="card-img-top" alt="${prod.name}" loading="lazy" width="300" height="300" style="object-fit:cover;aspect-ratio:1/1;"><div class="card-body p-2"><div class="mb-1">${StorefrontRuntime.renderProductBadgesHTML(prod)}</div><h6 class="card-title">${prod.name}</h6><p class="card-text mb-1">${StorefrontRuntime.formatPrice(prod.price, prod.currency)}</p></div></div></a>`;
+          const col = document.createElement('div');
+          col.className = 'col-6 col-md-4 col-lg-3 mb-4';
+          col.innerHTML = `
+            <div class="card h-100 simpleCart_shelfItem">
+              <a href="/p/${prod.slug}" class="text-decoration-none text-dark">
+                <img src="${prod.images[0]}" class="card-img-top item_thumb" alt="${prod.name}" loading="lazy" width="300" height="300" style="object-fit:cover;aspect-ratio:1/1;">
+              </a>
+              <div class="card-body p-2 d-flex flex-column">
+                <div class="mb-1">${StorefrontRuntime.renderProductBadgesHTML(prod)}</div>
+                <a href="/p/${prod.slug}" class="card-title h6 text-decoration-none text-dark item_name">${prod.name}</a>
+                <p class="card-text mb-1 item_price">${StorefrontRuntime.formatPrice(prod.price, prod.currency)}</p>
+                <button class="btn btn-primary mt-auto item_add" type="button">Add to Cart</button>
+              </div>
+            </div>`;
           grid.appendChild(col);
         });
       }

--- a/p/index.html
+++ b/p/index.html
@@ -47,13 +47,20 @@
           <div class="mt-2" id="image-thumbs"></div>
         </div>
         <div class="col-md-6">
-          <h1 id="product-title"></h1>
-          <div id="product-badges" class="mb-2"></div>
-          <p id="product-price" class="h4"></p>
-          <p id="stock-status"></p>
-          <p id="short-description"></p>
-          <div id="category-badges" class="mb-3"></div>
-          <section id="details"></section>
+          <div class="simpleCart_shelfItem">
+            <h1 id="product-title" class="item_name"></h1>
+            <div id="product-badges" class="mb-2"></div>
+            <p id="product-price" class="h4 item_price"></p>
+            <p id="stock-status"></p>
+            <p id="short-description"></p>
+            <div id="category-badges" class="mb-3"></div>
+            <div class="d-flex align-items-center mb-3">
+              <label for="product-qty" class="me-2">Qty</label>
+              <input id="product-qty" type="number" class="form-control item_Quantity" value="1" min="1" style="width:90px;">
+            </div>
+            <button type="button" class="btn btn-primary item_add mb-3">Add to Cart</button>
+            <section id="details"></section>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Render category product cards with simpleCart markup and add-to-cart buttons
- Add simpleCart cart controls to individual product pages with quantity selector

## Testing
- `npm run lint:static`
- `npm run validate:data`
- `npm run test:features` *(fails: Waiting for selector `#search-autocomplete:not(.d-none)` failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a522e870832088e4d75e0246cd5e