### PR TITLE
Unify product card rendering and retire simpleStore

### DIFF
--- a/assets/js/category-page.js
+++ b/assets/js/category-page.js
@@ -1,3 +1,5 @@
+import { buildProductCard } from './ui-cards.js';
+
 document.addEventListener('DOMContentLoaded', async () => {
   const parts = window.location.pathname.split('/').filter(Boolean);
   const slug = parts[1];
@@ -317,21 +319,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         grid.appendChild(p); grid.appendChild(link);
       } else {
         pageItems.forEach(prod => {
-          const col = document.createElement('div');
-          col.className = 'col-6 col-md-4 col-lg-3 mb-4';
-          col.innerHTML = `
-            <div class="card h-100 simpleCart_shelfItem">
-              <a href="/p/${prod.slug}" class="text-decoration-none text-dark">
-                <img src="${prod.images[0]}" class="card-img-top item_thumb" alt="${prod.name}" loading="lazy" width="300" height="300" style="object-fit:cover;aspect-ratio:1/1;">
-              </a>
-              <div class="card-body p-2 d-flex flex-column">
-                <div class="mb-1">${StorefrontRuntime.renderProductBadgesHTML(prod)}</div>
-                <a href="/p/${prod.slug}" class="card-title h6 text-decoration-none text-dark item_name">${prod.name}</a>
-                <p class="card-text mb-1 item_price">${StorefrontRuntime.formatPrice(prod.price, prod.currency)}</p>
-                <button class="btn btn-primary mt-auto item_add" type="button">Add to Cart</button>
-              </div>
-            </div>`;
-          grid.appendChild(col);
+          const card = buildProductCard(prod);
+          grid.appendChild(card);
         });
       }
       const nav = document.getElementById('pagination'); nav.innerHTML='';

--- a/assets/js/home-page.js
+++ b/assets/js/home-page.js
@@ -1,3 +1,5 @@
+import { buildProductCard } from './ui-cards.js';
+
 document.addEventListener('DOMContentLoaded', async () => {
   const container = document.getElementById('home-categories');
   if (!container) return;
@@ -44,22 +46,12 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const featured = document.getElementById('featured-products');
     if (featured) {
-      const row = document.createElement('div'); row.className='row';
-      products.slice(0,4).forEach(prod => {
-        const col=document.createElement('div'); col.className='col-6 col-md-3 mb-4';
-        col.innerHTML = `
-          <div class="card h-100 simpleCart_shelfItem">
-            <a href="/p/${prod.slug}" class="text-decoration-none text-dark">
-              <img src="${prod.images[0]}" class="card-img-top item_thumb" alt="${prod.name}" loading="lazy" width="300" height="300" style="object-fit:cover;aspect-ratio:1/1;">
-            </a>
-            <div class="card-body p-2 d-flex flex-column">
-              <div class="mb-1">${StorefrontRuntime.renderProductBadgesHTML(prod)}</div>
-              <a href="/p/${prod.slug}" class="card-title h6 text-decoration-none text-dark item_name">${prod.name}</a>
-              <p class="card-text mb-1 item_price">${StorefrontRuntime.formatPrice(prod.price, prod.currency)}</p>
-              <button class="btn btn-primary mt-auto item_add" type="button">Add to Cart</button>
-            </div>
-          </div>`;
-        row.appendChild(col);
+      const row = document.createElement('div');
+      row.className = 'row';
+      let items = products.filter(p => (p.tags || []).includes('featured'));
+      if (!items.length) items = products.slice(0,4);
+      items.slice(0,4).forEach(prod => {
+        row.appendChild(buildProductCard(prod));
       });
       featured.appendChild(row);
     }

--- a/assets/js/products-page.js
+++ b/assets/js/products-page.js
@@ -1,29 +1,18 @@
+import { buildProductCard } from './ui-cards.js';
+
 document.addEventListener('DOMContentLoaded', async () => {
   try {
-    const products = await StorefrontRuntime.loadProducts();
-    const grid = document.getElementById('product-grid');
-    products.forEach(prod => {
-      const col = document.createElement('div');
-      col.className = 'col-6 col-md-4 col-lg-3 mb-4';
-      col.innerHTML = `
-        <div class="card h-100 simpleCart_shelfItem">
-          <a href="/p/${prod.slug}" class="text-decoration-none text-dark">
-            <img src="${prod.images[0]}" class="card-img-top item_thumb" alt="${prod.name}" loading="lazy" width="300" height="300" style="object-fit:cover;aspect-ratio:1/1;">
-          </a>
-          <div class="card-body p-2 d-flex flex-column">
-            <div class="mb-1">${StorefrontRuntime.renderProductBadgesHTML(prod)}</div>
-            <a href="/p/${prod.slug}" class="card-title h6 text-decoration-none text-dark item_name">${prod.name}</a>
-            <p class="card-text mb-1 item_price">${StorefrontRuntime.formatPrice(prod.price, prod.currency)}</p>
-            <button class="btn btn-primary mt-auto item_add" type="button">Add to Cart</button>
-          </div>
-        </div>`;
-      grid.appendChild(col);
-    });
+    await StorefrontRuntime.loadProducts();
+    const grid = document.getElementById('products-grid');
+    const count = document.getElementById('product-count');
+
+    const all = StorefrontRuntime.getAllProducts();
+    grid.innerHTML = '';
+    all.forEach(p => grid.appendChild(buildProductCard(p)));
+    if (count) count.textContent = `${all.length} products`;
   } catch (e) {
     console.error(e);
-    const container = document.querySelector('.container');
-    if (container) {
-      container.innerHTML = `<div class="alert alert-danger">Error loading products. <button class="btn btn-link p-0" onclick="location.reload()">Retry</button></div>`;
-    }
+    const grid = document.getElementById('products-grid');
+    if (grid) grid.innerHTML = `<div class="alert alert-danger">Failed to load products.</div>`;
   }
 });

--- a/assets/js/search-page.js
+++ b/assets/js/search-page.js
@@ -1,3 +1,5 @@
+import { buildProductCard } from './ui-cards.js';
+
 document.addEventListener('DOMContentLoaded', async () => {
   const params = new URLSearchParams(window.location.search);
   const query = (params.get('q') || '').trim();
@@ -46,10 +48,8 @@ document.addEventListener('DOMContentLoaded', async () => {
       countEl.textContent = '0 results';
     } else {
       empty.classList.add('d-none');
-      pageItems.forEach(prod=>{
-        const col=document.createElement('div'); col.className='col-6 col-md-4 col-lg-3 mb-4';
-        col.innerHTML = `<a href="/p/${prod.slug}" class="text-decoration-none text-dark" style="display:block;min-width:44px;min-height:44px;"><div class="card h-100"><img src="${prod.images[0]}" class="card-img-top" alt="${prod.name}" loading="lazy" width="300" height="300" style="object-fit:cover;aspect-ratio:1/1;"><div class="card-body p-2"><div class="mb-1">${StorefrontRuntime.renderProductBadgesHTML(prod)}</div><h6 class="card-title">${prod.name}</h6><p class="card-text mb-1">${StorefrontRuntime.formatPrice(prod.price, prod.currency)}</p></div></div></a>`;
-        grid.appendChild(col);
+      pageItems.forEach(prod => {
+        grid.appendChild(buildProductCard(prod));
       });
       countEl.textContent = `${total} results`;
     }

--- a/assets/js/ui-cards.js
+++ b/assets/js/ui-cards.js
@@ -1,0 +1,26 @@
+// Renders a uniform, clickable simpleCart card for a product.
+export function buildProductCard(prod) {
+  // Defensive fallbacks
+  const img = (prod.images && prod.images[0]) || '/assets/img/products/fallback.png';
+  const price = prod.price; // numeric preferred
+  const currency = prod.currency || 'USD';
+
+  const col = document.createElement('div');
+  col.className = 'col-6 col-md-4 col-lg-3 mb-4';
+
+  col.innerHTML = `
+    <div class="card h-100 simpleCart_shelfItem">
+      <a href="/p/${prod.slug}" class="text-decoration-none text-dark">
+        <img src="${img}" class="card-img-top item_thumb" alt="${prod.name}" loading="lazy" width="300" height="300" style="object-fit:cover;aspect-ratio:1/1;">
+      </a>
+      <div class="card-body p-2 d-flex flex-column">
+        <div class="mb-1">${StorefrontRuntime.renderProductBadgesHTML(prod) || ''}</div>
+        <a href="/p/${prod.slug}" class="card-title h6 text-decoration-none text-dark item_name">${prod.name}</a>
+        <p class="card-text mb-1">
+          <span class="item_price" data-currency="${currency}">${StorefrontRuntime.formatPrice(price, currency)}</span>
+        </p>
+        <button class="btn btn-primary mt-auto item_add" type="button">Add to Cart</button>
+      </div>
+    </div>`;
+  return col;
+}

--- a/c/index.html
+++ b/c/index.html
@@ -96,7 +96,8 @@
   <script src="/assets/js/config.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/header-nav.js"></script>
-  <script src="/assets/js/category-page.js"></script>
+  <script type="module" src="/assets/js/ui-cards.js"></script>
+  <script type="module" src="/assets/js/category-page.js"></script>
   <script src="/assets/js/diagnostics-overlay.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -77,9 +77,10 @@
   <script src="./assets/js/bootstrap.bundle.min.js"></script>
   <script src="./assets/js/simpleCart.min.js"></script>
   <script src="./assets/js/config.js"></script>
-    <script src="./assets/js/storefront-runtime.js"></script>
-    <script src="./assets/js/header-nav.js"></script>
-    <script src="./assets/js/home-page.js"></script>
-    <script src="./assets/js/diagnostics-overlay.js" defer></script>
+  <script src="./assets/js/storefront-runtime.js"></script>
+  <script src="./assets/js/header-nav.js"></script>
+  <script type="module" src="./assets/js/ui-cards.js"></script>
+  <script type="module" src="./assets/js/home-page.js"></script>
+  <script src="./assets/js/diagnostics-overlay.js" defer></script>
   </body>
   </html>

--- a/products.html
+++ b/products.html
@@ -31,7 +31,8 @@
   <section class="py-5">
     <div class="container">
       <h1 class="text-center mb-4">Products</h1>
-      <div id="product-grid" class="row"></div>
+      <div id="product-count" class="visually-hidden" aria-live="polite"></div>
+      <div id="products-grid" class="row"></div>
     </div>
   </section>
 
@@ -54,7 +55,8 @@
   <script src="./assets/js/config.js"></script>
   <script src="./assets/js/storefront-runtime.js"></script>
   <script src="./assets/js/header-nav.js"></script>
-  <script src="./assets/js/products-page.js"></script>
+  <script type="module" src="./assets/js/ui-cards.js"></script>
+  <script type="module" src="./assets/js/products-page.js"></script>
   <script src="./assets/js/diagnostics-overlay.js" defer></script>
 </body>
 </html>

--- a/scripts/tests/features.js
+++ b/scripts/tests/features.js
@@ -34,6 +34,7 @@ function startServer(){
   const first = products[0];
   const second = products[1];
   const brand = first.brand || 'test';
+  const catSlug = (first.categories && first.categories[0]) || null;
   const report = [];
   let failed = false;
 
@@ -88,6 +89,52 @@ function startServer(){
   await page.goto(`http://localhost:${port}/search/?q=blossom`,{waitUntil:'networkidle0'});
   const hasBadge = await page.evaluate(()=>Array.from(document.querySelectorAll('#search-grid .badge')).some(b=>/Out of stock/i.test(b.textContent)));
   if (!hasBadge) {failed=true; report.push('Out of stock badge missing');}
+
+  // products page card checks
+  await page.goto(`http://localhost:${port}/products.html`,{waitUntil:'networkidle0'});
+  let pdata = await page.evaluate(()=>{
+    const grid = document.getElementById('products-grid');
+    const cards = Array.from(grid?.querySelectorAll('.simpleCart_shelfItem')||[]);
+    const ok = cards.length>0 && cards.every(c=>c.querySelector('a[href^="/p/"]') && c.querySelector('.item_add'));
+    return {grid: !!grid, ok, count: cards.length};
+  });
+  if (!pdata.grid || !pdata.ok) {failed=true; report.push('Products page cards incomplete');}
+
+  // category page card checks
+  if (catSlug){
+    await page.goto(`http://localhost:${port}/c/${catSlug}/`,{waitUntil:'networkidle0'});
+    pdata = await page.evaluate(()=>{
+      const grid = document.getElementById('product-grid');
+      const cards = Array.from(grid?.querySelectorAll('.simpleCart_shelfItem')||[]);
+      const ok = cards.length>0 && cards.every(c=>c.querySelector('a[href^="/p/"]') && c.querySelector('.item_add'));
+      return {grid: !!grid, ok, count: cards.length};
+    });
+    if (!pdata.grid || !pdata.ok) {failed=true; report.push('Category page cards incomplete');}
+  }
+
+  // product detail simpleCart hooks
+  await page.goto(`http://localhost:${port}/p/${first.slug}`,{waitUntil:'networkidle0'});
+  pdata = await page.evaluate(()=>({
+    name: !!document.querySelector('.simpleCart_shelfItem .item_name'),
+    price: !!document.querySelector('.simpleCart_shelfItem .item_price'),
+    qty: !!document.querySelector('.simpleCart_shelfItem .item_Quantity'),
+    add: !!document.querySelector('.simpleCart_shelfItem .item_add')
+  }));
+  if (!pdata.name || !pdata.price || !pdata.qty || !pdata.add) {failed=true; report.push('Product page missing cart hooks');}
+
+  // cart flow from listings
+  await page.goto(`http://localhost:${port}/products.html`,{waitUntil:'networkidle0'});
+  await page.click('#products-grid .item_add');
+  await page.waitForTimeout(500);
+  if (catSlug){
+    await page.goto(`http://localhost:${port}/c/${catSlug}/`,{waitUntil:'networkidle0'});
+    await page.click('#product-grid .item_add');
+    await page.waitForTimeout(500);
+  }
+  await page.goto(`http://localhost:${port}/cart.html`,{waitUntil:'networkidle0'});
+  const cartItems = await page.evaluate(()=>document.querySelectorAll('#cart-rows .row').length);
+  const expected = catSlug ? 2 : 1;
+  if (cartItems < expected) {failed=true; report.push('Cart missing items after adds');}
 
   await browser.close();
   server.close();

--- a/search/index.html
+++ b/search/index.html
@@ -72,7 +72,8 @@
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/header-nav.js"></script>
   <script src="/assets/js/search.js"></script>
-  <script src="/assets/js/search-page.js"></script>
+  <script type="module" src="/assets/js/ui-cards.js"></script>
+  <script type="module" src="/assets/js/search-page.js"></script>
   <script src="/assets/js/diagnostics-overlay.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add shared `buildProductCard` utility
- render products, categories, search and home featured items using the shared card
- update tests to validate cards and cart flows
- remove placeholder fallback image so it can be added separately

## Testing
- `npm run lint:static`
- `node scripts/tests/features.js` *(fails: Failed to launch the browser process)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b3aa6c748320a9eea3eb51b9215c