### PR TITLE
Fix missing product images in cart

### DIFF
--- a/assets/js/product-page.js
+++ b/assets/js/product-page.js
@@ -96,7 +96,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     backLink.href = backHref;
 
     const mainImg = document.getElementById('main-image');
-    mainImg.classList.add('item_image');
+    mainImg.classList.add('item_image', 'item_thumb');
     const thumbs = document.getElementById('image-thumbs');
     if (product.images && product.images.length) {
       mainImg.src = product.images[0];

--- a/assets/js/ui-cards.js
+++ b/assets/js/ui-cards.js
@@ -70,7 +70,7 @@ export function buildProductCard(prod) {
   col.innerHTML = `
     <div class="card h-100 simpleCart_shelfItem">
       <a href="/p/${prod.slug}" class="text-decoration-none text-dark">
-        <img src="${img}" class="card-img-top item_image" alt="${prod.name}" loading="lazy" decoding="async" onerror="this.src='/assets/img/products/fallback.png'" width="300" height="300" style="object-fit:cover;aspect-ratio:1/1;" srcset="${img} 300w, ${img} 600w" sizes="(max-width: 600px) 100vw, 300px">
+        <img src="${img}" class="card-img-top item_image item_thumb" alt="${prod.name}" loading="lazy" decoding="async" onerror="this.src='/assets/img/products/fallback.png'" width="300" height="300" style="object-fit:cover;aspect-ratio:1/1;" srcset="${img} 300w, ${img} 600w" sizes="(max-width: 600px) 100vw, 300px">
       </a>
       <div class="card-body p-2 d-flex flex-column">
         <span class="visually-hidden item_id">${prod.id || prod.slug}</span>

--- a/p/index.html
+++ b/p/index.html
@@ -42,7 +42,7 @@
       <a href="#" id="back-link" class="d-block mb-3">&laquo; Back</a>
       <div class="row">
         <div class="col-md-6">
-            <img id="main-image" class="img-fluid item_image" alt="" style="object-fit:cover;aspect-ratio:1/1;" width="600" height="600">
+            <img id="main-image" class="img-fluid item_image item_thumb" alt="" style="object-fit:cover;aspect-ratio:1/1;" width="600" height="600">
           <div class="mt-2" id="image-thumbs"></div>
         </div>
         <div class="col-md-6">


### PR DESCRIPTION
## Summary
- Include `item_thumb` class on product images so SimpleCart tracks thumbnails
- Add same class to product detail image to ensure cart thumbnails render

## Testing
- `npm run lint:static`
- `npm run validate:data`
- `npm run test:meta` *(fails: libgbm.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d2cc46c8832099a762e87cb38313