### PR TITLE
feat: add sticky header with search and cart

### DIFF
--- a/about.html
+++ b/about.html
@@ -11,22 +11,25 @@
   <link rel="stylesheet" href="./assets/css/custom.css">
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-light bg-light">
-    <div class="container">
-      <a class="navbar-brand" href="index.html"><img src="./assets/img/logo.png" alt="4D Cosmetics logo" width="40" height="40"></a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav ms-auto">
-          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
-          <li class="nav-item"><a class="nav-link active" href="about.html">About</a></li>
-          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
-          <li class="nav-item"><a class="nav-link" href="cart.html">Cart (<span class="simpleCart_quantity">0</span>)</a></li>
-        </ul>
-      </div>
+  <header class="site-header">
+  <div class="container nav-container">
+    <a href="/" class="logo">4DCosmetics</a>
+    <nav class="nav-links">
+      <a href="/c/makeup/">Makeup</a>
+      <a href="/c/perfume/">Perfume</a>
+      <a href="/c/skincare/">Skincare</a>
+      <a href="/c/accessories/">Accessories</a>
+    </nav>
+    <div class="nav-actions">
+      <form class="search-form" action="/search/" method="get">
+        <input type="search" name="q" placeholder="Search products…" aria-label="Search">
+      </form>
+      <a href="/cart.html" class="cart-link">
+        🛒 <span class="cart-count simpleCart_quantity">0</span>
+      </a>
     </div>
-  </nav>
+  </div>
+</header>
 
   <section class="hero" style="background-image:url('https://images.unsplash.com/photo-1500839941678-aae14dbfae9e?auto=format&fit=crop&w=1200&q=80');">
     <div class="container">

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -63,3 +63,62 @@ footer a:hover { text-decoration: underline; }
   align-items: center;
   justify-content: center;
 }
+/* Header styles */
+.site-header{
+  position: sticky;
+  top: 0;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
+  z-index: 50;
+}
+.nav-container{
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-6);
+}
+.nav-links a{
+  margin: 0 var(--space-3);
+  font-size: var(--font-size-300);
+  color: var(--text);
+  padding: var(--space-2) 0;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+}
+.nav-links a:hover{ color: var(--primary); }
+.nav-actions{ display:flex; align-items:center; }
+.search-form input{
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  width: 180px;
+}
+.cart-link{
+  margin-left: var(--space-4);
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+}
+.cart-count{
+  position: absolute;
+  top: -6px;
+  right: -10px;
+  background: var(--primary);
+  color: var(--primary-contrast);
+  border-radius: 50%;
+  padding: 2px 6px;
+  font-size: 12px;
+}
+@media (max-width: 768px){
+  .nav-links{ display: none; }
+  .nav-container{ flex-wrap: wrap; }
+  .nav-actions{
+    flex: 1 0 100%;
+    margin-top: var(--space-3);
+  }
+  .search-form{ flex: 1; }
+  .search-form input{ width: 100%; }
+}

--- a/c/index.html
+++ b/c/index.html
@@ -18,22 +18,25 @@
   <link rel="stylesheet" href="/assets/css/custom.css">
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-light bg-light">
-    <div class="container">
-      <a class="navbar-brand" href="/index.html"><img src="/assets/img/logo.png" alt="4D Cosmetics logo" width="40" height="40"></a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav ms-auto">
-          <li class="nav-item"><a class="nav-link" href="/index.html">Home</a></li>
-          <li class="nav-item"><a class="nav-link" href="/about.html">About</a></li>
-          <li class="nav-item"><a class="nav-link" href="/contact.html">Contact</a></li>
-          <li class="nav-item"><a class="nav-link" href="/cart.html">Cart (<span class="simpleCart_quantity">0</span>)</a></li>
-        </ul>
-      </div>
+  <header class="site-header">
+  <div class="container nav-container">
+    <a href="/" class="logo">4DCosmetics</a>
+    <nav class="nav-links">
+      <a href="/c/makeup/">Makeup</a>
+      <a href="/c/perfume/">Perfume</a>
+      <a href="/c/skincare/">Skincare</a>
+      <a href="/c/accessories/">Accessories</a>
+    </nav>
+    <div class="nav-actions">
+      <form class="search-form" action="/search/" method="get">
+        <input type="search" name="q" placeholder="Search products…" aria-label="Search">
+      </form>
+      <a href="/cart.html" class="cart-link">
+        🛒 <span class="cart-count simpleCart_quantity">0</span>
+      </a>
     </div>
-  </nav>
+  </div>
+</header>
 
   <section class="py-5">
     <div class="container">

--- a/cart.html
+++ b/cart.html
@@ -13,22 +13,25 @@
   <link rel="stylesheet" href="./assets/css/checkout.css">
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-light bg-light">
-    <div class="container">
-      <a class="navbar-brand" href="index.html"><img src="./assets/img/logo.png" alt="4D Cosmetics logo" width="40" height="40"></a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav ms-auto">
-          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
-          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
-          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
-          <li class="nav-item"><a class="nav-link active" href="cart.html">Cart (<span class="simpleCart_quantity">0</span>)</a></li>
-        </ul>
-      </div>
+  <header class="site-header">
+  <div class="container nav-container">
+    <a href="/" class="logo">4DCosmetics</a>
+    <nav class="nav-links">
+      <a href="/c/makeup/">Makeup</a>
+      <a href="/c/perfume/">Perfume</a>
+      <a href="/c/skincare/">Skincare</a>
+      <a href="/c/accessories/">Accessories</a>
+    </nav>
+    <div class="nav-actions">
+      <form class="search-form" action="/search/" method="get">
+        <input type="search" name="q" placeholder="Search products…" aria-label="Search">
+      </form>
+      <a href="/cart.html" class="cart-link">
+        🛒 <span class="cart-count simpleCart_quantity">0</span>
+      </a>
     </div>
-  </nav>
+  </div>
+</header>
 
   <main class="container">
     <h1>Your Cart (<span id="cart-count">0</span> items)</h1>

--- a/categories/index.html
+++ b/categories/index.html
@@ -12,22 +12,25 @@
   <link rel="stylesheet" href="/assets/css/custom.css">
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-light bg-light">
-    <div class="container">
-      <a class="navbar-brand" href="/index.html"><img src="/assets/img/logo.png" alt="4D Cosmetics logo" width="40" height="40"></a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav ms-auto">
-          <li class="nav-item"><a class="nav-link" href="/index.html">Home</a></li>
-          <li class="nav-item"><a class="nav-link" href="/about.html">About</a></li>
-          <li class="nav-item"><a class="nav-link" href="/contact.html">Contact</a></li>
-          <li class="nav-item"><a class="nav-link" href="/cart.html">Cart (<span class="simpleCart_quantity">0</span>)</a></li>
-        </ul>
-      </div>
+  <header class="site-header">
+  <div class="container nav-container">
+    <a href="/" class="logo">4DCosmetics</a>
+    <nav class="nav-links">
+      <a href="/c/makeup/">Makeup</a>
+      <a href="/c/perfume/">Perfume</a>
+      <a href="/c/skincare/">Skincare</a>
+      <a href="/c/accessories/">Accessories</a>
+    </nav>
+    <div class="nav-actions">
+      <form class="search-form" action="/search/" method="get">
+        <input type="search" name="q" placeholder="Search products…" aria-label="Search">
+      </form>
+      <a href="/cart.html" class="cart-link">
+        🛒 <span class="cart-count simpleCart_quantity">0</span>
+      </a>
     </div>
-  </nav>
+  </div>
+</header>
 
   <section class="py-5">
     <div class="container">

--- a/contact.html
+++ b/contact.html
@@ -11,22 +11,25 @@
   <link rel="stylesheet" href="./assets/css/custom.css">
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-light bg-light">
-    <div class="container">
-      <a class="navbar-brand" href="index.html"><img src="./assets/img/logo.png" alt="4D Cosmetics logo" width="40" height="40"></a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav ms-auto">
-          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
-          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
-          <li class="nav-item"><a class="nav-link active" href="contact.html">Contact</a></li>
-          <li class="nav-item"><a class="nav-link" href="cart.html">Cart (<span class="simpleCart_quantity">0</span>)</a></li>
-        </ul>
-      </div>
+  <header class="site-header">
+  <div class="container nav-container">
+    <a href="/" class="logo">4DCosmetics</a>
+    <nav class="nav-links">
+      <a href="/c/makeup/">Makeup</a>
+      <a href="/c/perfume/">Perfume</a>
+      <a href="/c/skincare/">Skincare</a>
+      <a href="/c/accessories/">Accessories</a>
+    </nav>
+    <div class="nav-actions">
+      <form class="search-form" action="/search/" method="get">
+        <input type="search" name="q" placeholder="Search products…" aria-label="Search">
+      </form>
+      <a href="/cart.html" class="cart-link">
+        🛒 <span class="cart-count simpleCart_quantity">0</span>
+      </a>
     </div>
-  </nav>
+  </div>
+</header>
 
   <section class="py-5">
     <div class="container">

--- a/index.html
+++ b/index.html
@@ -11,22 +11,25 @@
   <link rel="stylesheet" href="./assets/css/custom.css">
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-light bg-light">
-    <div class="container">
-      <a class="navbar-brand" href="index.html"><img src="./assets/img/logo.png" alt="4D Cosmetics logo" width="40" height="40"></a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav ms-auto">
-          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
-          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
-          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
-          <li class="nav-item"><a class="nav-link" href="cart.html">Cart (<span class="simpleCart_quantity">0</span>)</a></li>
-        </ul>
-      </div>
+  <header class="site-header">
+  <div class="container nav-container">
+    <a href="/" class="logo">4DCosmetics</a>
+    <nav class="nav-links">
+      <a href="/c/makeup/">Makeup</a>
+      <a href="/c/perfume/">Perfume</a>
+      <a href="/c/skincare/">Skincare</a>
+      <a href="/c/accessories/">Accessories</a>
+    </nav>
+    <div class="nav-actions">
+      <form class="search-form" action="/search/" method="get">
+        <input type="search" name="q" placeholder="Search products…" aria-label="Search">
+      </form>
+      <a href="/cart.html" class="cart-link">
+        🛒 <span class="cart-count simpleCart_quantity">0</span>
+      </a>
     </div>
-  </nav>
+  </div>
+</header>
 
     <section class="hero" style="background-image:url('https://images.unsplash.com/photo-1522335789203-aabd1fc54bc9?auto=format&fit=crop&w=1200&q=80');">
       <div class="container">

--- a/p/index.html
+++ b/p/index.html
@@ -18,22 +18,25 @@
   <link rel="stylesheet" href="/assets/css/custom.css">
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-light bg-light">
-    <div class="container">
-      <a class="navbar-brand" href="/index.html"><img src="/assets/img/logo.png" alt="4D Cosmetics logo" width="40" height="40"></a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav ms-auto">
-          <li class="nav-item"><a class="nav-link" href="/index.html">Home</a></li>
-          <li class="nav-item"><a class="nav-link" href="/about.html">About</a></li>
-          <li class="nav-item"><a class="nav-link" href="/contact.html">Contact</a></li>
-          <li class="nav-item"><a class="nav-link" href="/cart.html">Cart (<span class="simpleCart_quantity">0</span>)</a></li>
-        </ul>
-      </div>
+  <header class="site-header">
+  <div class="container nav-container">
+    <a href="/" class="logo">4DCosmetics</a>
+    <nav class="nav-links">
+      <a href="/c/makeup/">Makeup</a>
+      <a href="/c/perfume/">Perfume</a>
+      <a href="/c/skincare/">Skincare</a>
+      <a href="/c/accessories/">Accessories</a>
+    </nav>
+    <div class="nav-actions">
+      <form class="search-form" action="/search/" method="get">
+        <input type="search" name="q" placeholder="Search products…" aria-label="Search">
+      </form>
+      <a href="/cart.html" class="cart-link">
+        🛒 <span class="cart-count simpleCart_quantity">0</span>
+      </a>
     </div>
-  </nav>
+  </div>
+</header>
 
   <section class="py-5">
     <div class="container">

--- a/privacy.html
+++ b/privacy.html
@@ -11,22 +11,25 @@
   <link rel="stylesheet" href="./assets/css/custom.css">
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-light bg-light">
-    <div class="container">
-      <a class="navbar-brand" href="index.html"><img src="./assets/img/logo.png" alt="4D Cosmetics logo" width="40" height="40"></a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav ms-auto">
-          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
-          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
-          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
-          <li class="nav-item"><a class="nav-link" href="cart.html">Cart (<span class="simpleCart_quantity">0</span>)</a></li>
-        </ul>
-      </div>
+  <header class="site-header">
+  <div class="container nav-container">
+    <a href="/" class="logo">4DCosmetics</a>
+    <nav class="nav-links">
+      <a href="/c/makeup/">Makeup</a>
+      <a href="/c/perfume/">Perfume</a>
+      <a href="/c/skincare/">Skincare</a>
+      <a href="/c/accessories/">Accessories</a>
+    </nav>
+    <div class="nav-actions">
+      <form class="search-form" action="/search/" method="get">
+        <input type="search" name="q" placeholder="Search products…" aria-label="Search">
+      </form>
+      <a href="/cart.html" class="cart-link">
+        🛒 <span class="cart-count simpleCart_quantity">0</span>
+      </a>
     </div>
-  </nav>
+  </div>
+</header>
 
   <section class="py-5">
     <div class="container">

--- a/search/index.html
+++ b/search/index.html
@@ -13,22 +13,25 @@
   <link rel="stylesheet" href="/assets/css/custom.css">
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-light bg-light">
-    <div class="container">
-      <a class="navbar-brand" href="/index.html"><img src="/assets/img/logo.png" alt="4D Cosmetics logo" width="40" height="40"></a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav ms-auto">
-          <li class="nav-item"><a class="nav-link" href="/index.html">Home</a></li>
-          <li class="nav-item"><a class="nav-link" href="/about.html">About</a></li>
-          <li class="nav-item"><a class="nav-link" href="/contact.html">Contact</a></li>
-          <li class="nav-item"><a class="nav-link" href="/cart.html">Cart (<span class="simpleCart_quantity">0</span>)</a></li>
-        </ul>
-      </div>
+  <header class="site-header">
+  <div class="container nav-container">
+    <a href="/" class="logo">4DCosmetics</a>
+    <nav class="nav-links">
+      <a href="/c/makeup/">Makeup</a>
+      <a href="/c/perfume/">Perfume</a>
+      <a href="/c/skincare/">Skincare</a>
+      <a href="/c/accessories/">Accessories</a>
+    </nav>
+    <div class="nav-actions">
+      <form class="search-form" action="/search/" method="get">
+        <input type="search" name="q" placeholder="Search products…" aria-label="Search">
+      </form>
+      <a href="/cart.html" class="cart-link">
+        🛒 <span class="cart-count simpleCart_quantity">0</span>
+      </a>
     </div>
-  </nav>
+  </div>
+</header>
 
   <section class="py-5">
     <div class="container">

--- a/terms.html
+++ b/terms.html
@@ -11,22 +11,25 @@
   <link rel="stylesheet" href="./assets/css/custom.css">
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-light bg-light">
-    <div class="container">
-      <a class="navbar-brand" href="index.html"><img src="./assets/img/logo.png" alt="4D Cosmetics logo" width="40" height="40"></a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav ms-auto">
-          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
-          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
-          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
-          <li class="nav-item"><a class="nav-link" href="cart.html">Cart (<span class="simpleCart_quantity">0</span>)</a></li>
-        </ul>
-      </div>
+  <header class="site-header">
+  <div class="container nav-container">
+    <a href="/" class="logo">4DCosmetics</a>
+    <nav class="nav-links">
+      <a href="/c/makeup/">Makeup</a>
+      <a href="/c/perfume/">Perfume</a>
+      <a href="/c/skincare/">Skincare</a>
+      <a href="/c/accessories/">Accessories</a>
+    </nav>
+    <div class="nav-actions">
+      <form class="search-form" action="/search/" method="get">
+        <input type="search" name="q" placeholder="Search products…" aria-label="Search">
+      </form>
+      <a href="/cart.html" class="cart-link">
+        🛒 <span class="cart-count simpleCart_quantity">0</span>
+      </a>
     </div>
-  </nav>
+  </div>
+</header>
 
   <section class="py-5">
     <div class="container">

--- a/thank-you.html
+++ b/thank-you.html
@@ -13,22 +13,25 @@
   <link rel="stylesheet" href="./assets/css/checkout.css">
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-light bg-light">
-    <div class="container">
-      <a class="navbar-brand" href="index.html"><img src="./assets/img/logo.png" alt="4D Cosmetics logo" width="40" height="40"></a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav ms-auto">
-          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
-          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
-          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
-          <li class="nav-item"><a class="nav-link" href="cart.html">Cart (<span class="simpleCart_quantity">0</span>)</a></li>
-        </ul>
-      </div>
+  <header class="site-header">
+  <div class="container nav-container">
+    <a href="/" class="logo">4DCosmetics</a>
+    <nav class="nav-links">
+      <a href="/c/makeup/">Makeup</a>
+      <a href="/c/perfume/">Perfume</a>
+      <a href="/c/skincare/">Skincare</a>
+      <a href="/c/accessories/">Accessories</a>
+    </nav>
+    <div class="nav-actions">
+      <form class="search-form" action="/search/" method="get">
+        <input type="search" name="q" placeholder="Search products…" aria-label="Search">
+      </form>
+      <a href="/cart.html" class="cart-link">
+        🛒 <span class="cart-count simpleCart_quantity">0</span>
+      </a>
     </div>
-  </nav>
+  </div>
+</header>
 
   <main class="container thankyou-layout">
     <h1>Thank you</h1>


### PR DESCRIPTION
## Summary
- replace Bootstrap nav with sticky header including logo, nav links, search bar, and cart count
- add responsive header styles for desktop and mobile views

## Testing
- `npm run lint:static`

------
https://chatgpt.com/codex/tasks/task_e_68a57d0a686083208354aad048899eb3