### PR TITLE
feat: redesign product grid and cards

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -268,3 +268,27 @@ body.drawer-open{
     transition:none;
   }
 }
+
+/* Product grid and card styles */
+.product-grid{
+  display:grid;
+  grid-template-columns:repeat(2,1fr);
+  gap:var(--space-4);
+}
+@media (max-width:400px){
+  .product-grid{grid-template-columns:1fr;}
+}
+@media (min-width:768px){
+  .product-grid{grid-template-columns:repeat(3,1fr);}
+}
+@media (min-width:1024px){
+  .product-grid{grid-template-columns:repeat(4,1fr);}
+}
+.product-card{display:flex;}
+.product-card .card{width:100%;display:flex;flex-direction:column;}
+.product-card img{width:100%;height:auto;aspect-ratio:4/5;object-fit:cover;background:var(--surface);}
+.product-card .brand,.product-card .variant{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.price-block{display:flex;align-items:center;gap:var(--space-2);flex-wrap:nowrap;}
+.price-compare{text-decoration:line-through;color:var(--muted);font-size:var(--font-size-200);}
+.price-discount{color:var(--danger);font-size:var(--font-size-200);}
+.rating{color:var(--accent);font-size:var(--font-size-200);line-height:1;}

--- a/assets/js/ui-cards.js
+++ b/assets/js/ui-cards.js
@@ -64,44 +64,61 @@ export function buildProductCard(prod) {
   }
   const img = (prod.images && prod.images[0]) || '/assets/img/products/fallback.png';
   const priceNum = normalizePrice(prod.price);
+  const compareNum = normalizePrice(prod.compareAtPrice);
   const currency = prod.currency || 'USD';
 
-  const col = document.createElement('div');
-  col.className = 'col-6 col-md-4 col-lg-3 mb-4';
+  const wrap = document.createElement('div');
+  wrap.className = 'product-card';
 
-  const priceHTML = priceNum !== null
-    ? `<span class="visually-hidden item_price">${priceNum}</span><span aria-hidden="true" class="price-ui">${StorefrontRuntime.formatPrice(priceNum, currency)}</span>`
-    : `<span class="visually-hidden item_price"></span><span aria-hidden="true" class="price-ui">Unavailable</span>`;
+  let priceHTML = '';
+  if (priceNum !== null) {
+    priceHTML = `<span class="visually-hidden item_price">${priceNum}</span><span aria-hidden="true" class="price-current">${StorefrontRuntime.formatPrice(priceNum, currency)}</span>`;
+    if (compareNum !== null && compareNum > priceNum) {
+      const pct = Math.round((1 - priceNum / compareNum) * 100);
+      priceHTML += ` <span class="price-compare">${StorefrontRuntime.formatPrice(compareNum, currency)}</span> <span class="price-discount">${pct}% off</span>`;
+    }
+  } else {
+    priceHTML = `<span class="visually-hidden item_price"></span><span aria-hidden="true" class="price-current">Unavailable</span>`;
+  }
 
-  const disabled = priceNum === null ? 'disabled' : '';
-  const btnLabel = priceNum === null ? 'Unavailable' : 'Add to Cart';
+  const disabled = priceNum === null || prod.inStock === false;
+  const actionHTML = disabled
+    ? `<a href="/p/${prod.slug}" class="btn btn-secondary mt-auto" aria-label="View details for ${prod.name}">View details</a>`
+    : `<button class="btn btn-primary mt-auto item_add" type="button" aria-label="Add ${prod.name} to cart">Add to Cart</button>`;
 
-  col.innerHTML = `
+  const ratingHTML = prod.rating
+    ? `<div class="rating mb-1" aria-label="Rated ${prod.rating} out of 5">${'★'.repeat(Math.round(prod.rating))}${'☆'.repeat(5 - Math.round(prod.rating))} <span class="text-muted small">(${prod.ratingCount || 0})</span></div>`
+    : '';
+
+  wrap.innerHTML = `
     <div class="card h-100 simpleCart_shelfItem">
       <a href="/p/${prod.slug}" class="text-decoration-none text-dark">
-        <img src="${img}" class="card-img-top item_image item_thumb" alt="${prod.name}" loading="lazy" decoding="async" onerror="this.src='/assets/img/products/fallback.png'" width="300" height="300" style="object-fit:cover;aspect-ratio:1/1;" srcset="${img} 300w, ${img} 600w" sizes="(max-width: 600px) 100vw, 300px">
+        <img src="${img}" class="card-img-top item_image item_thumb" alt="${prod.name}" loading="lazy" decoding="async" onerror="this.src='/assets/img/products/fallback.png'" width="300" height="375" srcset="${img} 300w, ${img} 600w" sizes="(max-width: 600px) 100vw, 300px">
       </a>
       <div class="card-body p-2 d-flex flex-column">
         <span class="visually-hidden item_id">${prod.id || prod.slug}</span>
         <span class="visually-hidden item_url">/p/${prod.slug}</span>
         <div class="mb-1">${StorefrontRuntime.renderProductBadgesHTML(prod) || ''}</div>
+        ${prod.brand ? `<p class="brand mb-1 small text-muted">${prod.brand}</p>` : ''}
         <a href="/p/${prod.slug}" class="card-title h6 text-decoration-none text-dark item_name">${prod.name}</a>
-        <p class="card-text mb-1">${priceHTML}</p>
-        <button class="btn btn-primary mt-auto item_add" type="button" aria-label="Add ${prod.name} to cart" ${disabled}>${btnLabel}</button>
+        ${prod.variant ? `<p class="variant text-muted mb-1">${prod.variant}</p>` : ''}
+        ${ratingHTML}
+        <p class="card-text price-block mb-1">${priceHTML}</p>
+        ${actionHTML}
       </div>
     </div>`;
 
-  const btn = col.querySelector('.item_add');
-  if (priceNum !== null) {
+  if (!disabled) {
+    const btn = wrap.querySelector('.item_add');
     btn.addEventListener('click', () => {
       Analytics.addToCart(prod, 1);
       showAddedToast(prod.name);
     });
   }
-  col.querySelectorAll('a[href^="/p/"]').forEach(a => {
+  wrap.querySelectorAll('a[href^="/p/"]').forEach(a => {
     a.addEventListener('click', () => Analytics.selectItem(prod));
   });
-  return col;
+  return wrap;
 }
 
 // expose helpers globally

--- a/c/index.html
+++ b/c/index.html
@@ -59,7 +59,7 @@
             </div>
           </div>
           <div id="product-count" class="visually-hidden" aria-live="polite"></div>
-          <div class="row" id="product-grid"></div>
+          <div class="product-grid" id="product-grid"></div>
           <nav class="mt-4" id="pagination"></nav>
         </div>
       </div>

--- a/search/index.html
+++ b/search/index.html
@@ -47,7 +47,7 @@
           <option value="newest">Newest</option>
         </select>
       </div>
-      <div id="search-grid" class="row"></div>
+      <div id="search-grid" class="product-grid"></div>
       <div id="search-empty" class="d-none">
         <p>No products found for “<span id="empty-query"></span>”.</p>
         <div id="empty-links"></div>


### PR DESCRIPTION
## Summary
- replace Bootstrap rows with token-based CSS grid on search and category pages
- expand product cards with brand, discount pricing and out-of-stock handling
- add responsive card grid styles and rating/discount styling tokens

## Testing
- `npm run lint:static`
- `npm run test:features` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a591d608a083208283716473cfb454