### PR TITLE
feat: add load-more pagination for product listings

### DIFF
--- a/assets/js/category-page.js
+++ b/assets/js/category-page.js
@@ -142,6 +142,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     const productsAll = StorefrontRuntime.listProductsForCategory(slug);
     const brands = Array.from(new Set(productsAll.map(p=>p.brand).filter(Boolean))).sort();
     const tagsAll = Array.from(new Set(productsAll.flatMap(p=>p.tags||[]))).sort();
+    let currentItems = [];
+    let totalPages = 1;
+    let loadedPage = 0;
+    const grid = document.getElementById('product-grid');
+    const productCount = document.getElementById('product-count');
+    const loadMoreBtn = document.getElementById('load-more');
+    const loadMoreContainer = document.getElementById('load-more-container');
     // sanitize state for unknown values
     state.brand = state.brand.filter(b=>brands.includes(b));
     state.tags = state.tags.filter(t=>tagsAll.includes(t));
@@ -303,53 +310,68 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     function render(scroll=true) {
-      const grid = document.getElementById('product-grid');
       grid.innerHTML='';
-      let items = filterProducts(productsAll);
-      items = sortProducts(items);
-      const total = items.length;
+      loadedPage = 0;
+      currentItems = sortProducts(filterProducts(productsAll));
+      const total = currentItems.length;
       grid.setAttribute('data-total', total);
-      const productCount = document.getElementById('product-count');
       productCount.textContent = `${total} products`;
-      const totalPages = Math.ceil(total / perPage) || 1;
+      totalPages = Math.ceil(total / perPage) || 1;
       if (state.page > totalPages) { state.page = totalPages; replaceURL(); }
-      const pageItems = StorefrontRuntime.paginateArray(items, state.page, perPage);
-      if (pageItems.length === 0) {
+      if (total === 0) {
         const p = document.createElement('p'); p.textContent = 'No products match your filters.';
         const link = document.createElement('a'); link.href='#'; link.textContent='Clear filters'; link.addEventListener('click', e=>{e.preventDefault(); clearFilters();});
         grid.appendChild(p); grid.appendChild(link);
-      } else {
-        const rendered=[];
-        pageItems.forEach(prod => {
-          const card = buildProductCard(prod);
-          if (card){ grid.appendChild(card); rendered.push(prod); }
-        });
-        Analytics.viewItemList(rendered, category.name);
-        if (ldEl) {
-          ld[1] = {
-            "@context": "https://schema.org",
-            "@type": "ItemList",
-            "itemListElement": rendered.map((p,i)=>({"@type":"ListItem","position":i+1,"url":`${window.location.origin}/p/${p.slug}`}))
-          };
-          ldEl.textContent = JSON.stringify(ld);
-        }
+        updateLoadMore();
+        return;
       }
-      const nav = document.getElementById('pagination'); nav.innerHTML='';
-      if (totalPages > 1 && pageItems.length) {
-        const ulp = document.createElement('ul'); ulp.className='pagination';
-        const prev = document.createElement('li'); const prevA=document.createElement('a'); prevA.className='page-link'; prevA.textContent='Previous'; prevA.style.minWidth='44px'; prevA.style.minHeight='44px';
-        if (state.page === 1){ prev.className='page-item disabled'; prevA.setAttribute('aria-disabled','true'); prevA.tabIndex=-1; } else { prev.className='page-item'; prevA.href = buildQuery({page: state.page-1}); }
-        prev.appendChild(prevA); ulp.appendChild(prev);
-        for(let i=1;i<=totalPages;i++){
-          const li=document.createElement('li'); li.className='page-item'+(i===state.page?' active':'');
-          const a=document.createElement('a'); a.className='page-link'; a.textContent=i; a.style.minWidth='44px'; a.style.minHeight='44px'; if(i!==state.page) a.href=buildQuery({page:i}); li.appendChild(a); ulp.appendChild(li);
-        }
-        const next=document.createElement('li'); const nextA=document.createElement('a'); nextA.className='page-link'; nextA.textContent='Next'; nextA.style.minWidth='44px'; nextA.style.minHeight='44px';
-        if (state.page === totalPages){ next.className='page-item disabled'; nextA.setAttribute('aria-disabled','true'); nextA.tabIndex=-1; } else { next.className='page-item'; nextA.href=buildQuery({page: state.page+1}); }
-        next.appendChild(nextA); ulp.appendChild(next); nav.appendChild(ulp);
+      while (loadedPage < state.page) {
+        appendNextPage();
       }
-      if (scroll) document.getElementById('product-grid').scrollIntoView();
+      updateLoadMore();
+      if (scroll) grid.scrollIntoView();
     }
+
+    function appendNextPage() {
+      const start = loadedPage * perPage;
+      const pageItems = currentItems.slice(start, start + perPage);
+      if (!pageItems.length) return;
+      const rendered = [];
+      pageItems.forEach(prod => {
+        const card = buildProductCard(prod);
+        if (card){ grid.appendChild(card); rendered.push(prod); }
+      });
+      loadedPage++;
+      Analytics.viewItemList(rendered, category.name);
+      updateLD();
+    }
+
+    function updateLoadMore() {
+      if (loadedPage >= totalPages) {
+        loadMoreContainer.classList.add('d-none');
+      } else {
+        loadMoreContainer.classList.remove('d-none');
+      }
+    }
+
+    function updateLD() {
+      if (!ldEl) return;
+      ld[1] = {
+        "@context": "https://schema.org",
+        "@type": "ItemList",
+        "itemListElement": currentItems.slice(0, loadedPage * perPage).map((p,i)=>({"@type":"ListItem","position":i+1,"url":`${window.location.origin}/p/${p.slug}`}))
+      };
+      ldEl.textContent = JSON.stringify(ld);
+    }
+    loadMoreBtn.addEventListener('click', () => {
+      if (loadedPage < totalPages) {
+        state.page = loadedPage + 1;
+        replaceURL();
+        appendNextPage();
+        updateLoadMore();
+        Analytics.loadMoreClick(category.name);
+      }
+    });
 
     render(false);
   } catch (e) {

--- a/assets/js/search-page.js
+++ b/assets/js/search-page.js
@@ -11,8 +11,14 @@ document.addEventListener('DOMContentLoaded', async () => {
   const grid = document.getElementById('search-grid');
   const sortSel = document.getElementById('sort');
   const perPage = 12;
+  const loadMoreBtn = document.getElementById('load-more');
+  const loadMoreContainer = document.getElementById('load-more-container');
   let sort = params.get('sort') || 'featured';
   let page = parseInt(params.get('page') || '1',10);
+  let currentItems = [];
+  let loadedPage = 0;
+  let totalPages = 1;
+  const ldEl = document.getElementById('ld-json');
   if (!query) { heading.textContent = 'Search'; return; }
   heading.textContent = `Search results for "${query}"`;
   sortSel.value = sort;
@@ -36,47 +42,58 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   function render(){
-    let items = sortProducts(results);
-    const total = items.length;
-    const totalPages = Math.ceil(total/perPage)||1;
-    if (page>totalPages) page=totalPages;
-    const pageItems = StorefrontRuntime.paginateArray(items,page,perPage);
     grid.innerHTML='';
-    if (!pageItems.length){
+    loadedPage = 0;
+    currentItems = sortProducts(results);
+    const total = currentItems.length;
+    totalPages = Math.ceil(total/perPage)||1;
+    if (page>totalPages) page=totalPages;
+    if (!total){
       empty.classList.remove('d-none');
       emptyQuery.textContent = query;
       countEl.textContent = '0 results';
+      updateLoadMore();
+      return;
+    }
+    empty.classList.add('d-none');
+    countEl.textContent = `${total} results`;
+    while (loadedPage < page) {
+      appendNextPage();
+    }
+    updateLoadMore();
+  }
+
+  function appendNextPage(){
+    const start = loadedPage * perPage;
+    const pageItems = currentItems.slice(start, start + perPage);
+    if (!pageItems.length) return;
+    const rendered = [];
+    pageItems.forEach(prod => {
+      const card = buildProductCard(prod);
+      if (card){ grid.appendChild(card); rendered.push(prod); }
+    });
+    loadedPage++;
+    Analytics.viewItemList(rendered, 'Search results');
+    updateLD();
+  }
+
+  function updateLoadMore(){
+    if (loadedPage >= totalPages){
+      loadMoreContainer.classList.add('d-none');
     } else {
-      empty.classList.add('d-none');
-      const rendered=[];
-      pageItems.forEach(prod => {
-        const card = buildProductCard(prod);
-        if (card){ grid.appendChild(card); rendered.push(prod); }
-      });
-      countEl.textContent = `${total} results`;
-      Analytics.viewItemList(rendered, 'Search results');
-      const ldEl = document.getElementById('ld-json');
-      if (ldEl){
-        const ld = {
-          "@context": "https://schema.org",
-          "@type": "ItemList",
-          "itemListElement": rendered.map((p,i)=>({"@type":"ListItem","position":i+1,"url":`${window.location.origin}/p/${p.slug}`}))
-        };
-        ldEl.textContent = JSON.stringify(ld);
-      }
+      loadMoreContainer.classList.remove('d-none');
     }
-    const nav = document.getElementById('pagination'); nav.innerHTML='';
-    if (total>perPage){
-      const totalPages = Math.ceil(total/perPage);
-      const ul=document.createElement('ul'); ul.className='pagination';
-      const prev=document.createElement('li'); const prevA=document.createElement('a'); prevA.className='page-link'; prevA.textContent='Previous'; prevA.style.minWidth='44px'; prevA.style.minHeight='44px';
-      if (page===1){ prev.className='page-item disabled'; prevA.setAttribute('aria-disabled','true'); prevA.tabIndex=-1; } else { prev.className='page-item'; prevA.href=buildURL({page:page-1}); }
-      prev.appendChild(prevA); ul.appendChild(prev);
-      for(let i=1;i<=totalPages;i++){ const li=document.createElement('li'); li.className='page-item'+(i===page?' active':''); const a=document.createElement('a'); a.className='page-link'; a.textContent=i; a.style.minWidth='44px'; a.style.minHeight='44px'; if(i!==page) a.href=buildURL({page:i}); li.appendChild(a); ul.appendChild(li); }
-      const next=document.createElement('li'); const nextA=document.createElement('a'); nextA.className='page-link'; nextA.textContent='Next'; nextA.style.minWidth='44px'; nextA.style.minHeight='44px';
-      if (page===totalPages){ next.className='page-item disabled'; nextA.setAttribute('aria-disabled','true'); nextA.tabIndex=-1; } else { next.className='page-item'; nextA.href=buildURL({page:page+1}); }
-      next.appendChild(nextA); ul.appendChild(next); nav.appendChild(ul);
-    }
+  }
+
+  function updateLD(){
+    if (!ldEl) return;
+    const shown = currentItems.slice(0, loadedPage * perPage);
+    const ld = {
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      "itemListElement": shown.map((p,i)=>({"@type":"ListItem","position":i+1,"url":`${window.location.origin}/p/${p.slug}`}))
+    };
+    ldEl.textContent = JSON.stringify(ld);
   }
 
   function buildURL(extra){
@@ -89,6 +106,16 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   sortSel.addEventListener('change', () => {
     sort = sortSel.value; page=1; window.history.replaceState({},'',buildURL({})); render();
+  });
+
+  loadMoreBtn.addEventListener('click', () => {
+    if (loadedPage < totalPages) {
+      page = loadedPage + 1;
+      window.history.replaceState({}, '', buildURL({page}));
+      appendNextPage();
+      updateLoadMore();
+      Analytics.loadMoreClick('Search results');
+    }
   });
 
   render();

--- a/assets/js/ui-cards.js
+++ b/assets/js/ui-cards.js
@@ -35,6 +35,9 @@ export const Analytics = {
   },
   newsletterSignup() {
     fireEvent('sign_up', { method: 'homepage_newsletter' });
+  },
+  loadMoreClick(listName = 'Listing') {
+    fireEvent('load_more_click', { item_list_name: listName });
   }
 };
 

--- a/c/index.html
+++ b/c/index.html
@@ -60,7 +60,9 @@
           </div>
           <div id="product-count" class="visually-hidden" aria-live="polite"></div>
           <div class="product-grid" id="product-grid"></div>
-          <nav class="mt-4" id="pagination"></nav>
+          <div class="text-center mt-4" id="load-more-container">
+            <button id="load-more" class="btn btn-outline-primary" style="min-width:44px;min-height:44px;">Load more</button>
+          </div>
         </div>
       </div>
     </div>

--- a/search/index.html
+++ b/search/index.html
@@ -52,7 +52,9 @@
         <p>No products found for “<span id="empty-query"></span>”.</p>
         <div id="empty-links"></div>
       </div>
-      <nav id="pagination" class="mt-3"></nav>
+      <div class="text-center mt-4" id="load-more-container">
+        <button id="load-more" class="btn btn-outline-primary" style="min-width:44px;min-height:44px;">Load more</button>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- replace numbered pagination on category and search pages with a load more button
- track load_more_click analytics events
- update product listing scripts to append results and support deep-linked pages

## Testing
- `npm run lint:static`
- `npm run test:features` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a59a82e25c832097fc61f9d5554c6c