### PR TITLE
feat: add variant selection and mobile ATC

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -292,3 +292,31 @@ body.drawer-open{
 .price-compare{text-decoration:line-through;color:var(--muted);font-size:var(--font-size-200);}
 .price-discount{color:var(--danger);font-size:var(--font-size-200);}
 .rating{color:var(--accent);font-size:var(--font-size-200);line-height:1;}
+
+/* Variant swatches */
+.variant-swatch{
+  width:44px;
+  height:44px;
+  border:1px solid var(--border);
+  border-radius:50%;
+  cursor:pointer;
+  display:inline-block;
+}
+.variant-swatch.selected{outline:2px solid var(--primary);}
+.variant-swatch:focus-visible{outline:2px solid var(--primary);outline-offset:2px;}
+.variant-swatch[disabled]{opacity:.4;cursor:not-allowed;}
+
+/* Mobile add-to-cart bar */
+.mobile-atc{
+  position:fixed;
+  bottom:0;
+  left:0;
+  right:0;
+  background:var(--surface);
+  border-top:1px solid var(--border);
+  padding:var(--space-3) var(--space-4);
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  box-shadow:var(--shadow-sm);
+}

--- a/assets/data/products.json
+++ b/assets/data/products.json
@@ -12,7 +12,41 @@
     "shortDescription": "Rich color with a creamy matte finish.",
     "descriptionHTML": "<p>Rich color with a creamy matte finish.</p>",
     "inStock": true,
-    "sku": "LIP001"
+    "sku": "LIP001",
+    "variants": [
+      {
+        "id": "LIP001-ROSE01",
+        "name": "Rose 01",
+        "color": "#C07082",
+        "image": "/assets/img/products/lipstick.jpeg",
+        "price": 19.99,
+        "inStock": true,
+        "sku": "LIP001-ROSE01"
+      },
+      {
+        "id": "LIP001-CORAL02",
+        "name": "Coral 02",
+        "color": "#E86C5D",
+        "image": "/assets/img/products/lipstick.jpeg",
+        "price": 19.99,
+        "inStock": true,
+        "sku": "LIP001-CORAL02"
+      },
+      {
+        "id": "LIP001-BERRY03",
+        "name": "Berry 03",
+        "color": "#8B3F64",
+        "image": "/assets/img/products/lipstick.jpeg",
+        "price": 19.99,
+        "inStock": false,
+        "sku": "LIP001-BERRY03"
+      }
+    ],
+    "details": ["Rich color", "Creamy matte finish", "Long-lasting"],
+    "howTo": ["Apply to lips", "Layer for intensity"],
+    "ingredients": "Ricinus Communis (Castor) Seed Oil, Caprylic/Capric Triglyceride, etc.",
+    "goodToKnow": "Vegan and cruelty-free",
+    "shippingReturns": "Ships in 3-5 days. 30-day returns."
   },
   {
     "id": "FND001",

--- a/assets/js/product-page.js
+++ b/assets/js/product-page.js
@@ -24,22 +24,75 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     document.getElementById('product-title').textContent = product.name;
     document.getElementById('product-badges').innerHTML = StorefrontRuntime.renderProductBadgesHTML(product);
-    const priceNum = normalizePrice(product.price);
     const priceEl = document.getElementById('product-price');
     const addBtn = document.querySelector('.item_add');
     const currency = product.currency || 'USD';
-    if (priceNum !== null) {
-      priceEl.innerHTML = `<span class="visually-hidden item_price">${priceNum}</span><span aria-hidden="true" class="price-ui">${StorefrontRuntime.formatPrice(priceNum, currency)}</span>`;
-      addBtn.disabled = false;
-      addBtn.textContent = 'Add to Cart';
-    } else {
-      priceEl.innerHTML = `<span class="visually-hidden item_price"></span><span aria-hidden="true" class="price-ui">Unavailable</span>`;
-      addBtn.disabled = true;
-      addBtn.textContent = 'Unavailable';
+    const stockEl = document.getElementById('stock-status');
+    const variantWrap = document.getElementById('variant-options');
+    const idEl = document.getElementById('product-id');
+    const mainImg = document.getElementById('main-image');
+    const liveRegion = document.getElementById('live-region');
+    let currentVariant = null;
+
+    if (Array.isArray(product.variants) && product.variants.length) {
+      const param = StorefrontRuntime.getQueryParam('variant');
+      currentVariant = product.variants.find(v => v.id === param) || product.variants[0];
+      variantWrap.setAttribute('role', 'radiogroup');
+      product.variants.forEach(v => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'variant-swatch me-2 mb-2';
+        if (v.color) btn.style.backgroundColor = v.color;
+        btn.title = v.name;
+        btn.setAttribute('aria-label', `Shade: ${v.name}`);
+        btn.dataset.variant = v.id;
+        btn.disabled = v.inStock === false;
+        btn.addEventListener('click', () => { applyVariant(v); updateSwatches(); });
+        variantWrap.appendChild(btn);
+      });
     }
-    document.getElementById('stock-status').textContent = product.inStock ? 'In stock' : 'Out of stock';
+
+    function applyVariant(v){
+      currentVariant = v;
+      const priceNum = normalizePrice(v && v.price !== undefined ? v.price : product.price);
+      if (priceNum !== null) {
+        priceEl.innerHTML = `<span class="visually-hidden item_price">${priceNum}</span><span aria-hidden="true" class="price-ui">${StorefrontRuntime.formatPrice(priceNum, currency)}</span>`;
+        addBtn.disabled = v && v.inStock === false;
+        addBtn.textContent = v && v.inStock === false ? 'Notify me' : 'Add to Cart';
+      } else {
+        priceEl.innerHTML = `<span class="visually-hidden item_price"></span><span aria-hidden="true" class="price-ui">Unavailable</span>`;
+        addBtn.disabled = true;
+        addBtn.textContent = 'Unavailable';
+      }
+      stockEl.textContent = v && v.inStock === false ? 'Out of stock' : 'In stock';
+      if (idEl) idEl.textContent = v ? v.id : product.id || product.slug;
+      if (v && v.image) { mainImg.src = v.image; mainImg.alt = `${product.name} - ${v.name}`; }
+      StorefrontRuntime.setQueryParam('variant', v ? v.id : null);
+      const mobileInfo = document.getElementById('mobile-atc-info');
+      if (mobileInfo) mobileInfo.textContent = `${v ? v.name : product.name} • ${StorefrontRuntime.formatPrice(normalizePrice(v && v.price !== undefined ? v.price : product.price), currency)}`;
+      if (liveRegion) liveRegion.textContent = `${v ? v.name : ''} selected`;
+    }
+
+    function updateSwatches(){
+      variantWrap.querySelectorAll('.variant-swatch').forEach(btn => {
+        const sel = currentVariant && btn.dataset.variant === currentVariant.id;
+        btn.classList.toggle('selected', sel);
+        btn.setAttribute('aria-pressed', sel ? 'true' : 'false');
+      });
+    }
+
     document.getElementById('short-description').textContent = product.shortDescription || '';
-    if (product.descriptionHTML) document.getElementById('details').innerHTML = product.descriptionHTML;
+    if (Array.isArray(product.details) && product.details.length) {
+      document.getElementById('details').innerHTML = '<ul>' + product.details.map(d=>`<li>${d}</li>`).join('') + '</ul>';
+    } else if (product.descriptionHTML) document.getElementById('details').innerHTML = product.descriptionHTML;
+    if (Array.isArray(product.howTo) && product.howTo.length) document.getElementById('how-to').innerHTML = '<ol>' + product.howTo.map(d=>`<li>${d}</li>`).join('') + '</ol>';
+    if (product.ingredients) document.getElementById('ingredients').textContent = product.ingredients;
+    if (product.goodToKnow) document.getElementById('good-to-know').textContent = product.goodToKnow;
+    if (product.shippingReturns) document.getElementById('shipping-returns').textContent = product.shippingReturns;
+    ['details','how-to','ingredients','good-to-know','shipping-returns'].forEach(id => {
+      const el = document.getElementById(id);
+      if (el && !el.textContent.trim()) el.parentElement.remove();
+    });
 
     const breadcrumb = document.getElementById('breadcrumb');
     const firstCatSlug = product.categories && product.categories[0];
@@ -69,8 +122,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     }];
     document.getElementById('ld-json').textContent = JSON.stringify(ld);
 
-    const idEl = document.getElementById('product-id');
-    if (idEl) idEl.textContent = product.id || product.slug;
     const urlEl = document.getElementById('product-url');
     if (urlEl) urlEl.href = canonicalUrl;
 
@@ -99,8 +150,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     mainImg.classList.add('item_image', 'item_thumb');
     const thumbs = document.getElementById('image-thumbs');
     if (product.images && product.images.length) {
-      mainImg.src = product.images[0];
-      mainImg.alt = product.name;
+      if (!currentVariant || !currentVariant.image) {
+        mainImg.src = product.images[0];
+        mainImg.alt = product.name;
+      }
       mainImg.loading = 'eager';
       mainImg.decoding = 'async';
       mainImg.onerror = function(){ this.src='/assets/img/products/fallback.png'; };
@@ -120,15 +173,29 @@ document.addEventListener('DOMContentLoaded', async () => {
       mainImg.src = '/assets/img/products/fallback.png';
       mainImg.alt = product.name || '';
     }
+    if (currentVariant) applyVariant(currentVariant);
 
     const qtyEl = document.getElementById('product-qty');
     if (addBtn) {
       addBtn.setAttribute('aria-label', `Add ${product.name} to cart`);
       addBtn.addEventListener('click', () => {
         const qty = parseInt(qtyEl.value,10) || 1;
-        Analytics.addToCart(product, qty);
-        showAddedToast(product.name);
+        const item = currentVariant ? {...product, ...currentVariant} : product;
+        Analytics.addToCart(item, qty);
+        if (liveRegion) liveRegion.textContent = 'Added to cart';
+        showAddedToast(item.name);
       });
+    }
+    const mobileBtn = document.getElementById('mobile-atc-btn');
+    if (mobileBtn) mobileBtn.addEventListener('click', () => addBtn.click());
+
+    const summary = document.getElementById('summary');
+    const mobileBar = document.getElementById('mobile-atc-bar');
+    if (summary && mobileBar) {
+      const io = new IntersectionObserver(([entry]) => {
+        mobileBar.hidden = entry.isIntersecting;
+      });
+      io.observe(summary);
     }
 
     StorefrontRuntime.addRecentlyViewed(product.slug);

--- a/assets/schemas/products.schema.json
+++ b/assets/schemas/products.schema.json
@@ -26,7 +26,35 @@
       "shortDescription": {"type": "string"},
       "descriptionHTML": {"type": "string"},
       "inStock": {"type": "boolean"},
-      "sku": {"type": "string"}
+      "sku": {"type": "string"},
+      "variants": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["id", "name"],
+          "properties": {
+            "id": {"type": "string"},
+            "name": {"type": "string"},
+            "color": {"type": "string"},
+            "image": {"type": "string"},
+            "price": {"type": "number"},
+            "inStock": {"type": "boolean"},
+            "sku": {"type": "string"}
+          },
+          "additionalProperties": false
+        }
+      },
+      "details": {
+        "type": "array",
+        "items": {"type": "string"}
+      },
+      "howTo": {
+        "type": "array",
+        "items": {"type": "string"}
+      },
+      "ingredients": {"type": "string"},
+      "goodToKnow": {"type": "string"},
+      "shippingReturns": {"type": "string"}
     },
     "additionalProperties": false
   }

--- a/p/index.html
+++ b/p/index.html
@@ -49,7 +49,7 @@
             <img id="main-image" class="img-fluid item_image item_thumb" alt="" style="object-fit:cover;aspect-ratio:1/1;" width="600" height="600">
           <div class="mt-2" id="image-thumbs"></div>
         </div>
-        <div class="col-md-6">
+        <div class="col-md-6" id="summary">
           <div class="simpleCart_shelfItem">
             <h1 id="product-title" class="item_name"></h1>
             <div id="product-badges" class="mb-2"></div>
@@ -59,17 +59,45 @@
             <p id="stock-status"></p>
             <p id="short-description"></p>
             <div id="category-badges" class="mb-3"></div>
+            <div id="variant-options" class="mb-3"></div>
             <div class="d-flex align-items-center mb-3">
               <label for="product-qty" class="me-2">Qty</label>
               <input id="product-qty" type="number" class="form-control item_Quantity" value="1" min="1" style="width:90px;">
             </div>
             <button type="button" class="btn btn-primary item_add mb-3">Add to Cart</button>
-            <section id="details"></section>
+            <section id="details-accordion" class="mt-4">
+              <details open>
+                <summary>Details</summary>
+                <div id="details"></div>
+              </details>
+              <details>
+                <summary>How to use</summary>
+                <div id="how-to"></div>
+              </details>
+              <details>
+                <summary>Ingredients</summary>
+                <div id="ingredients"></div>
+              </details>
+              <details>
+                <summary>Good to know</summary>
+                <div id="good-to-know"></div>
+              </details>
+              <details>
+                <summary>Shipping &amp; returns</summary>
+                <div id="shipping-returns"></div>
+              </details>
+            </section>
           </div>
         </div>
       </div>
     </div>
   </section>
+
+  <div id="mobile-atc-bar" class="mobile-atc d-md-none" hidden>
+    <span id="mobile-atc-info"></span>
+    <button type="button" id="mobile-atc-btn" class="btn btn-primary">Add to Cart</button>
+  </div>
+  <div id="live-region" class="visually-hidden" aria-live="polite"></div>
 
   <section class="py-5 d-none" id="recently-viewed-section">
     <div class="container">


### PR DESCRIPTION
## Summary
- add product variant schema and sample variants
- implement variant swatches, details accordion, and mobile sticky add-to-cart
- style swatches and mobile bar with design tokens

## Testing
- `npm run validate:data`
- `npm run lint:static`
- `npm run test:meta` *(fails: libatk-1.0.so.0 missing)*
- `npm run test:sitemap`
- `npm run test:spa` *(fails: libatk-1.0.so.0 missing)*
- `npm run test:features` *(fails: libatk-1.0.so.0 missing)*
- `npm run test:lighthouse` *(fails: CHROME_PATH not set)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a30e984083208be25731bf5be458