### PR TITLE
Add review hooks and analytics bootstrap

### DIFF
--- a/assets/js/reviews-bundle.js
+++ b/assets/js/reviews-bundle.js
@@ -1,0 +1,3 @@
+// Placeholder for the asynchronously loaded reviews bundle.
+// In a real implementation this would hydrate the reviews UI.
+console.log('reviews bundle loaded');

--- a/assets/js/reviews.js
+++ b/assets/js/reviews.js
@@ -1,0 +1,91 @@
+// Basic reviews bootstrap and analytics hooks.
+// Initializes lazy-loading and dispatches analytics events.
+
+function fire(event, data) {
+  try {
+    if (window.gtag) {
+      window.gtag('event', event, data);
+    } else if (window.Analytics && typeof window.Analytics[event] === 'function') {
+      // fallback to Analytics object if available
+      window.Analytics[event](data);
+    } else {
+      console.debug('analytics event', event, data);
+    }
+  } catch (e) {
+    console.warn('analytics error', e);
+  }
+}
+
+function observeOnce(el, options, callback) {
+  if (!el) return;
+  const io = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        io.disconnect();
+        callback(entry.target);
+      }
+    });
+  }, options);
+  io.observe(el);
+}
+
+function lazyLoadSection() {
+  const section = document.querySelector('[data-region="reviews"]');
+  observeOnce(section, { rootMargin: '200px' }, () => {
+    import('./reviews-bundle.js').catch(() => {
+      console.warn('reviews bundle failed to load');
+    });
+  });
+}
+
+function trackSummary() {
+  const summary = document.querySelector('[data-region="reviews-summary"]');
+  observeOnce(summary, { rootMargin: '0px 0px -50% 0px' }, () => {
+    fire('reviews_summary_impression');
+  });
+}
+
+function initAnalyticsEvents() {
+  document.addEventListener('click', (e) => {
+    const open = e.target.closest('[data-action="review-open"]');
+    if (open) fire('reviews_open_form');
+
+    const helpful = e.target.closest('[data-action="review-helpful"]');
+    if (helpful) {
+      fire('review_helpful_click', {
+        id: helpful.dataset.reviewId,
+        vote: helpful.dataset.vote
+      });
+    }
+
+    const report = e.target.closest('[data-action="review-report"]');
+    if (report) fire('review_report_click', { id: report.dataset.reviewId });
+
+    const loadMore = e.target.closest('[data-action="reviews-load-more"]');
+    if (loadMore) fire('reviews_load_more');
+  });
+
+  document.addEventListener('change', (e) => {
+    const controls = e.target.closest('[data-component="reviews-controls"]');
+    if (!controls) return;
+    const el = e.target;
+    if (el.name === 'sort') {
+      fire('reviews_sort_change', { value: el.value });
+    } else {
+      fire('reviews_filter_change', { name: el.name, value: el.value });
+    }
+  });
+}
+
+if (document.readyState !== 'loading') {
+  trackSummary();
+  lazyLoadSection();
+  initAnalyticsEvents();
+} else {
+  document.addEventListener('DOMContentLoaded', () => {
+    trackSummary();
+    lazyLoadSection();
+    initAnalyticsEvents();
+  });
+}
+

--- a/p/index.html
+++ b/p/index.html
@@ -56,6 +56,11 @@
             <span id="product-id" class="visually-hidden item_id"></span>
             <a id="product-url" href="#" class="visually-hidden item_url"></a>
             <p id="product-price" class="h4"></p>
+            <div data-region="reviews-summary" class="mb-3 small">
+              <!-- review summary injected here -->
+              <a href="#reviews" class="me-2">Read reviews</a>
+              <a href="#reviews" data-action="review-open">Write a review</a>
+            </div>
             <p id="stock-status"></p>
             <p id="short-description"></p>
             <div id="category-badges" class="mb-3"></div>
@@ -98,6 +103,17 @@
     <button type="button" id="mobile-atc-btn" class="btn btn-primary">Add to Cart</button>
   </div>
   <div id="live-region" class="visually-hidden" aria-live="polite"></div>
+  <section class="py-5" id="reviews" data-region="reviews">
+    <div class="container">
+      <div class="d-flex justify-content-between align-items-center mb-4">
+        <h2 class="h3 mb-0">Reviews</h2>
+        <button type="button" class="btn btn-primary" data-action="review-open">Write a review</button>
+      </div>
+      <div data-component="reviews-controls" class="mb-4"></div>
+      <div data-component="reviews-list"></div>
+      <button type="button" class="btn btn-outline-secondary mt-4" data-action="reviews-load-more">Load more</button>
+    </div>
+  </section>
 
   <section class="py-5 d-none" id="recently-viewed-section">
     <div class="container">
@@ -126,6 +142,7 @@
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/header-nav.js"></script>
   <script type="module" src="/assets/js/product-page.js"></script>
+  <script type="module" src="/assets/js/reviews.js"></script>
   <script src="/assets/js/diagnostics-overlay.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add markup containers for review summary and full reviews section on product pages
- Introduce `reviews.js` to lazy-load reviews bundle and dispatch analytics events
- Stub out asynchronous `reviews-bundle.js` module

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:static` (fails: unknown category links)
- `npm run validate:data`


------
https://chatgpt.com/codex/tasks/task_e_68a5b7e7fe3083209200ff5e57b96f6a