### PR TITLE
feat: add shared SEO config and schema emitter

### DIFF
--- a/assets/js/category-page.js
+++ b/assets/js/category-page.js
@@ -1,4 +1,5 @@
 import { buildProductCard, Analytics } from './ui-cards.js';
+import { applySEO } from './seo.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
   const parts = window.location.pathname.split('/').filter(Boolean);
@@ -102,30 +103,34 @@ document.addEventListener('DOMContentLoaded', async () => {
     const category = StorefrontRuntime.findCategoryBySlug(slug);
     if (!category) return render404();
     const canonicalUrl = `${window.location.origin}/c/${category.slug}/`;
-    document.title = `${category.name} | 4D Cosmetics`;
-    document.getElementById('canonical-link').setAttribute('href', canonicalUrl);
-    const meta = document.querySelector('meta[name="description"]');
     let metaDesc = '';
-    if (meta && category.descriptionHTML) {
+    if (category.descriptionHTML) {
       const tmp = document.createElement('div');
       tmp.innerHTML = category.descriptionHTML;
       metaDesc = tmp.textContent.trim().slice(0,160);
-      meta.setAttribute('content', metaDesc);
-    } else if (meta) meta.remove();
-    document.getElementById('og-title').setAttribute('content', `${category.name} | 4D Cosmetics`);
-    if (metaDesc) document.getElementById('og-description').setAttribute('content', metaDesc); else document.getElementById('og-description').remove();
-    document.getElementById('og-url').setAttribute('content', canonicalUrl);
-    if (category.image) document.getElementById('og-image').setAttribute('content', category.image); else document.getElementById('og-image').remove();
-    const ld = [{
-      "@context": "https://schema.org",
-      "@type": "BreadcrumbList",
-      "itemListElement": [
-        {"@type":"ListItem","position":1,"name":"Home","item":`${window.location.origin}/`},
-        {"@type":"ListItem","position":2,"name":category.name,"item":canonicalUrl}
-      ]
-    }];
-    const ldEl = document.getElementById('ld-json');
-    if (ldEl) ldEl.textContent = JSON.stringify(ld);
+    }
+    applySEO({
+      canonical: canonicalUrl,
+      title: `${category.name} | 4D Cosmetics`,
+      description: metaDesc,
+      robots: 'index,follow',
+      og: {
+        type: 'website',
+        title: `${category.name} | 4D Cosmetics`,
+        description: metaDesc,
+        image: category.image || undefined,
+        url: canonicalUrl
+      },
+      twitter: { card: 'summary_large_image' },
+      schemaBlocks: [{
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {"@type":"ListItem","position":1,"name":"Home","item":`${window.location.origin}/`},
+          {"@type":"ListItem","position":2,"name":category.name,"item":canonicalUrl}
+        ]
+      }]
+    });
     document.getElementById('category-title').textContent = category.name;
     if (category.descriptionHTML) document.getElementById('category-description').innerHTML = category.descriptionHTML;
     const breadcrumb = document.getElementById('breadcrumb');

--- a/assets/js/product-page.js
+++ b/assets/js/product-page.js
@@ -1,4 +1,5 @@
 import { normalizePrice, showAddedToast, Analytics } from './ui-cards.js';
+import { applySEO } from './seo.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
   const parts = window.location.pathname.split('/').filter(Boolean);
@@ -9,18 +10,49 @@ document.addEventListener('DOMContentLoaded', async () => {
     const product = StorefrontRuntime.getProductBySlug(slug);
     if (!product) return render404();
     const canonicalUrl = `${window.location.origin}/p/${product.slug}`;
-    document.title = `${product.name} | 4D Cosmetics`;
-    document.getElementById('canonical-link').setAttribute('href', canonicalUrl);
-    const meta = document.querySelector('meta[name="description"]');
+    const firstCatSlug = product.categories && product.categories[0];
+    const firstCat = firstCatSlug ? StorefrontRuntime.findCategoryBySlug(firstCatSlug) : null;
     let metaDesc = '';
-    if (meta && product.shortDescription) {
-      metaDesc = product.shortDescription.slice(0,160);
-      meta.setAttribute('content', metaDesc);
-    } else if (meta) { meta.remove(); }
-    document.getElementById('og-title').setAttribute('content', `${product.name} | 4D Cosmetics`);
-    if (metaDesc) document.getElementById('og-description').setAttribute('content', metaDesc); else document.getElementById('og-description').remove();
-    document.getElementById('og-url').setAttribute('content', canonicalUrl);
-    if (product.images && product.images.length) document.getElementById('og-image').setAttribute('content', product.images[0]); else document.getElementById('og-image').remove();
+    if (product.shortDescription) metaDesc = product.shortDescription.slice(0,160);
+    const priceNum = normalizePrice(product.price);
+    applySEO({
+      canonical: canonicalUrl,
+      title: `${product.name} | 4D Cosmetics`,
+      description: metaDesc,
+      robots: 'index,follow',
+      og: {
+        type: 'product',
+        title: `${product.name} | 4D Cosmetics`,
+        description: metaDesc,
+        image: product.images && product.images.length ? product.images[0] : undefined,
+        url: canonicalUrl
+      },
+      twitter: { card: 'summary_large_image' },
+      schemaBlocks: [{
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {"@type":"ListItem","position":1,"name":"Home","item":`${window.location.origin}/`},
+          ...(firstCat ? [{"@type":"ListItem","position":2,"name":firstCat.name,"item":`${window.location.origin}/c/${firstCat.slug}/`}] : []),
+          {"@type":"ListItem","position": firstCat ? 3 : 2, "name": product.name, "item": canonicalUrl}
+        ]
+      },{
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "name": product.name,
+        ...(metaDesc ? {"description": metaDesc} : {}),
+        ...(product.images && product.images.length ? {"image": product.images} : {}),
+        ...(product.sku ? {"sku": product.sku} : {}),
+        ...(product.brand ? {"brand": {"@type":"Brand","name":product.brand}} : {}),
+        "offers": {
+          "@type": "Offer",
+          "price": priceNum !== null ? priceNum : undefined,
+          "priceCurrency": product.currency,
+          "availability": product.inStock ? "https://schema.org/InStock" : "https://schema.org/OutOfStock",
+          "url": canonicalUrl
+        }
+      }]
+    });
 
     document.getElementById('product-title').textContent = product.name;
     document.getElementById('product-badges').innerHTML = StorefrontRuntime.renderProductBadgesHTML(product);
@@ -95,32 +127,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
     const breadcrumb = document.getElementById('breadcrumb');
-    const firstCatSlug = product.categories && product.categories[0];
-    let firstCat = firstCatSlug ? StorefrontRuntime.findCategoryBySlug(firstCatSlug) : null;
     breadcrumb.innerHTML = `<li class="breadcrumb-item"><a href="/">Home</a></li>` + (firstCat ? `<li class="breadcrumb-item"><a href="/c/${firstCat.slug}/">${firstCat.name}</a></li>` : '') + `<li class="breadcrumb-item active" aria-current="page">${product.name}</li>`;
-    const ld = [{
-      "@context": "https://schema.org",
-      "@type": "BreadcrumbList",
-      "itemListElement": [
-        {"@type":"ListItem","position":1,"name":"Home","item":`${window.location.origin}/`},
-        ...(firstCat ? [{"@type":"ListItem","position":2,"name":firstCat.name,"item":`${window.location.origin}/c/${firstCat.slug}/`}] : []),
-        {"@type":"ListItem","position": firstCat ? 3 : 2, "name": product.name, "item": canonicalUrl}
-      ]
-    },{
-      "@context": "https://schema.org",
-      "@type": "Product",
-      "name": product.name,
-      ...(product.images && product.images.length ? {"image": product.images} : {}),
-      ...(product.sku ? {"sku": product.sku} : {}),
-      "offers": {
-        "@type": "Offer",
-        "price": priceNum !== null ? priceNum : undefined,
-        "priceCurrency": product.currency,
-        "availability": product.inStock ? "https://schema.org/InStock" : "https://schema.org/OutOfStock"
-      },
-      ...(product.brand ? {"brand": {"@type":"Brand","name":product.brand}} : {})
-    }];
-    document.getElementById('ld-json').textContent = JSON.stringify(ld);
 
     const urlEl = document.getElementById('product-url');
     if (urlEl) urlEl.href = canonicalUrl;

--- a/assets/js/seo.js
+++ b/assets/js/seo.js
@@ -1,0 +1,113 @@
+export function applySEO(cfg = {}) {
+  const {
+    canonical,
+    title,
+    description,
+    robots,
+    og = {},
+    twitter = {},
+    schemaBlocks = []
+  } = cfg;
+
+  if (title) document.title = title;
+
+  let link = document.querySelector('link[rel="canonical"]');
+  if (canonical) {
+    if (!link) {
+      link = document.createElement('link');
+      link.rel = 'canonical';
+      document.head.appendChild(link);
+    }
+    link.href = canonical;
+  } else if (link) {
+    link.remove();
+  }
+
+  let descEl = document.querySelector('meta[name="description"]');
+  if (description) {
+    if (!descEl) {
+      descEl = document.createElement('meta');
+      descEl.name = 'description';
+      document.head.appendChild(descEl);
+    }
+    descEl.setAttribute('content', description);
+  } else if (descEl) {
+    descEl.remove();
+  }
+
+  let robotsEl = document.querySelector('meta[name="robots"]');
+  if (robots) {
+    if (!robotsEl) {
+      robotsEl = document.createElement('meta');
+      robotsEl.name = 'robots';
+      document.head.appendChild(robotsEl);
+    }
+    robotsEl.setAttribute('content', robots);
+  } else if (robotsEl) {
+    robotsEl.remove();
+  }
+
+  const ogDefaults = {
+    type: 'website',
+    url: canonical || window.location.href,
+    image: `${window.location.origin}/assets/img/logo.png`,
+    title,
+    description
+  };
+  const ogData = { ...ogDefaults, ...og };
+  ['type', 'title', 'description', 'image', 'url'].forEach(key => {
+    const prop = `og:${key}`;
+    let el = document.querySelector(`meta[property="${prop}"]`);
+    if (ogData[key]) {
+      if (!el) {
+        el = document.createElement('meta');
+        el.setAttribute('property', prop);
+        document.head.appendChild(el);
+      }
+      el.setAttribute('content', ogData[key]);
+    } else if (el) {
+      el.remove();
+    }
+  });
+
+  if (twitter.card) {
+    let tw = document.querySelector('meta[name="twitter:card"]');
+    if (!tw) {
+      tw = document.createElement('meta');
+      tw.name = 'twitter:card';
+      document.head.appendChild(tw);
+    }
+    tw.setAttribute('content', twitter.card);
+  }
+
+  const baseBlocks = [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Organization',
+      'name': '4D Cosmetics',
+      'url': `${window.location.origin}/`,
+      'logo': `${window.location.origin}/assets/img/logo.png`
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'WebSite',
+      'url': `${window.location.origin}/`,
+      'potentialAction': {
+        '@type': 'SearchAction',
+        'target': `${window.location.origin}/search/?q={search_term_string}`,
+        'query-input': 'required name=search_term_string'
+      }
+    }
+  ];
+  const blocks = [...baseBlocks, ...schemaBlocks];
+  if (blocks.length) {
+    let ld = document.getElementById('ld-json');
+    if (!ld) {
+      ld = document.createElement('script');
+      ld.type = 'application/ld+json';
+      ld.id = 'ld-json';
+      document.head.appendChild(ld);
+    }
+    ld.textContent = JSON.stringify(blocks);
+  }
+}

--- a/scripts/tests/meta-jsonld-snapshots.js
+++ b/scripts/tests/meta-jsonld-snapshots.js
@@ -58,8 +58,11 @@ function startServer() {
     ld: document.getElementById('ld-json')?.textContent || ''
   }));
   if (!data.ogImage) {failed=true; report.push('Category with image missing og:image');}
-  const ldCat = data.ld ? JSON.parse(data.ld) : null;
-  if (!ldCat || ldCat['@type'] !== 'BreadcrumbList') {failed=true; report.push('Category breadcrumb missing');}
+  const ldCat = data.ld ? JSON.parse(data.ld) : [];
+  const breadcrumbOk = Array.isArray(ldCat)
+    ? ldCat.some(i => i['@type'] === 'BreadcrumbList')
+    : ldCat['@type'] === 'BreadcrumbList';
+  if (!breadcrumbOk) {failed=true; report.push('Category breadcrumb missing');}
   page.removeAllListeners('request');
   await page.setRequestInterception(false);
 


### PR DESCRIPTION
## Summary
- add reusable `applySEO` helper to set canonical, meta, OG/Twitter tags and inject consolidated JSON-LD
- wire category and product pages to build SEO config objects and use helper
- adjust meta/JSON-LD snapshot test for multiple schema blocks

## Testing
- `npm run validate:data`
- `npm run lint:static`
- `npm run test:sitemap`
- `npm run test:meta` *(fails: libXcomposite.so.1 missing)*
- `npm run test:spa` *(fails: libXcomposite.so.1 missing)*
- `npm run test:lighthouse` *(fails: CHROME_PATH not set)*
- `npm run test:features` *(fails: libXcomposite.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bbe749288320b483ad3b7acb3f0e