### PR TITLE
Add basic analytics event bus and consent manager

### DIFF
--- a/assets/js/analytics/consent.js
+++ b/assets/js/analytics/consent.js
@@ -1,0 +1,55 @@
+const ConsentManager = (() => {
+  const KEY = 'site_consent';
+  const VERSION = 1;
+  const listeners = [];
+
+  function read() {
+    try {
+      const raw = localStorage.getItem(KEY);
+      if (!raw) return defaultConsent();
+      const data = JSON.parse(raw);
+      if (data.version !== VERSION) return defaultConsent();
+      return {
+        necessary: true,
+        analytics: !!data.analytics,
+        marketing: !!data.marketing,
+        version: VERSION,
+        ts: data.ts || new Date().toISOString()
+      };
+    } catch {
+      return defaultConsent();
+    }
+  }
+
+  function defaultConsent() {
+    return {
+      necessary: true,
+      analytics: false,
+      marketing: false,
+      version: VERSION,
+      ts: new Date().toISOString()
+    };
+  }
+
+  let consent = read();
+
+  function save(next) {
+    consent = { ...consent, ...next, necessary: true, version: VERSION, ts: new Date().toISOString() };
+    try {
+      localStorage.setItem(KEY, JSON.stringify(consent));
+    } catch {}
+    listeners.forEach(cb => cb(consent));
+  }
+
+  function onChange(cb) {
+    listeners.push(cb);
+  }
+
+  function getConsent() {
+    return consent;
+  }
+
+  return { getConsent, save, onChange };
+})();
+
+export default ConsentManager;

--- a/assets/js/analytics/event-bus.js
+++ b/assets/js/analytics/event-bus.js
@@ -1,0 +1,79 @@
+import ConsentManager from './consent.js';
+
+const EventBus = (() => {
+  let seq = 0;
+  const queue = [];
+  let flushing = false;
+  const dedupe = new Set();
+
+  function sessionId() {
+    let id = sessionStorage.getItem('session_id');
+    if (!id) {
+      id = crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2);
+      sessionStorage.setItem('session_id', id);
+    }
+    return id;
+  }
+
+  function baseEvent(evt) {
+    const now = new Date().toISOString();
+    const consent = ConsentManager.getConsent();
+    return {
+      event: evt.event,
+      ts: now,
+      context: {
+        pageType: document.body.getAttribute('data-page') || 'unknown',
+        pageUrl: location.href,
+        referrer: document.referrer || '',
+        language: document.documentElement.lang || 'en',
+        currency: 'USD',
+        deviceClass: /Mobi/.test(navigator.userAgent) ? 'mobile' : 'desktop'
+      },
+      user: { loggedIn: false, userId: undefined, consent },
+      session: { id: sessionId(), seq: ++seq },
+      ecommerce: evt.ecommerce || undefined,
+      meta: evt.meta || undefined,
+      clientEventId: crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2)
+    };
+  }
+
+  function route(eventObj, category) {
+    const consent = eventObj.user.consent;
+    if (category === 'analytics' && !consent.analytics) return;
+    if (category === 'marketing' && !consent.marketing) return;
+
+    if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
+      console.log('event', eventObj);
+    }
+
+    try {
+      navigator.sendBeacon && navigator.sendBeacon('/api/events', JSON.stringify(eventObj));
+    } catch {}
+  }
+
+  function flush() {
+    flushing = false;
+    const items = queue.splice(0, queue.length);
+    dedupe.clear();
+    items.forEach(({ evt, category }) => route(baseEvent(evt), category));
+  }
+
+  function dispatch(eventName, payload = {}, category = 'analytics') {
+    const key = eventName + JSON.stringify(payload);
+    if (dedupe.has(key)) return;
+    dedupe.add(key);
+    queue.push({ evt: { event: eventName, ...payload }, category });
+    if (!flushing) {
+      flushing = true;
+      setTimeout(flush, 0);
+    }
+  }
+
+  ConsentManager.onChange(consent => {
+    dispatch('consent_state_change', { meta: { consent } }, 'necessary');
+  });
+
+  return { dispatch };
+})();
+
+export default EventBus;

--- a/assets/js/analytics/index.js
+++ b/assets/js/analytics/index.js
@@ -1,0 +1,7 @@
+import EventBus from './event-bus.js';
+import ConsentManager from './consent.js';
+
+window.analytics = {
+  dispatch: EventBus.dispatch,
+  consent: ConsentManager
+};

--- a/assets/js/header-nav.js
+++ b/assets/js/header-nav.js
@@ -14,11 +14,7 @@ document.documentElement.classList.add('js');
 
 function navEvent(type, data = {}) {
   try {
-    if (window.gtag) {
-      window.gtag('event', type, data);
-    } else if (window.dataLayer) {
-      window.dataLayer.push({ event: type, ...data });
-    }
+    window.analytics && window.analytics.dispatch(type, { meta: data }, 'analytics');
   } catch (e) {
     console.warn('analytics error', e);
   }

--- a/index.html
+++ b/index.html
@@ -147,6 +147,7 @@
   <script src="./assets/js/bootstrap.bundle.min.js"></script>
   <script src="./assets/js/simpleCart.min.js"></script>
   <script src="./assets/js/config.js"></script>
+  <script type="module" src="./assets/js/analytics/index.js"></script>
   <script src="./assets/js/storefront-runtime.js"></script>
   <script src="./assets/js/footer.js"></script>
   <script src="./assets/js/header-nav.js"></script>


### PR DESCRIPTION
## Summary
- add consent manager to store and notify preference changes
- implement event bus stamping context, session, and routing based on consent
- wire navigation events to new analytics bus and load analytics script on homepage

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static` *(fails: Link issues: unknown category link /c/skincare/, /c/accessories/)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bc8b2598832084ac89bbcae2002c