### PR TITLE
Add RBORY Kiss Lipstick product

### DIFF
--- a/assets/data/products.json
+++ b/assets/data/products.json
@@ -227,5 +227,20 @@
     "descriptionHTML": "<p>Long Lasting Setting Spray that locks in makeup for a flawless, fresh look all day</p>",
     "inStock": true,
     "sku": "FIX002"
+  },
+  {
+    "id": "LIP003",
+    "name": "RBORY Kiss Lipstick",
+    "slug": "rbory-kiss-lipstick",
+    "images": ["/assets/img/products/IMG-20250816-WA0050.jpg"],
+    "price": 550,
+    "currency": "PKR",
+    "categories": ["makeup", "lipsticks"],
+    "brand": "RBORY",
+    "tags": ["makeup"],
+    "shortDescription": "A richly pigmented kiss-proof lipstick that glides on smoothly for bold, long-lasting color",
+    "descriptionHTML": "<p>A richly pigmented kiss-proof lipstick that glides on smoothly for bold, long-lasting color</p>",
+    "inStock": true,
+    "sku": "LIP003"
   }
 ]

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -30,4 +30,6 @@
   <url><loc>https://4dcosmetics.com/p/rbory-water-moisturizing-makeup-face-primer</loc></url>
   <url><loc>https://4dcosmetics.com/p/rbory-makeup-fixer</loc></url>
   <url><loc>https://4dcosmetics.com/p/sk-forever-skin-nourishing-liquid-foundation</loc></url>
+  <url><loc>https://4dcosmetics.com/p/rbory-makeup-setting-spray</loc></url>
+  <url><loc>https://4dcosmetics.com/p/rbory-kiss-lipstick</loc></url>
 </urlset>


### PR DESCRIPTION
## Summary
- add RBORY Kiss Lipstick to product catalog
- update sitemap with RBORY Kiss Lipstick and missing RBORY Makeup Setting Spray URLs

## Testing
- `npm run validate:data`
- `npm run test:sitemap`
- `npm run lint:static` *(fails: unknown category links)*
- `npm run test:meta` *(fails: Navigation timeout exceeded)*
- `npm run test:spa` *(fails: Product direct load failed)*
- `npm run test:lighthouse` *(fails: CHROME_PATH not set)*
- `npm run test:features` *(fails: Waiting for selector #header-search failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c6172b0083209fedcba5cdb8129b