### PR TITLE
feat: add reusable product card component

### DIFF
--- a/assets/css/product-card.css
+++ b/assets/css/product-card.css
@@ -1,0 +1,41 @@
+/* Grid alignment */
+.product-grid{ display:grid; gap: var(--space-5); grid-template-columns: repeat(auto-fill, minmax(190px,1fr)); }
+
+/* Card basics */
+.pc{ position:relative; display:flex; flex-direction:column; overflow:hidden; }
+.pc__link{ position:absolute; inset:0; z-index:1; }
+.pc__media{ position:relative; }
+.pc__img, .pc__img--alt{ width:100%; height:100%; object-fit:cover; display:block; transition:opacity .25s ease; }
+.pc__img--alt{ position:absolute; inset:0; opacity:0; }
+@media (hover:hover){
+  .pc:hover .pc__img--alt{ opacity:1; }
+}
+
+/* Badges */
+.pc__badges{ position:absolute; top:8px; left:8px; display:flex; flex-direction:column; gap:6px; z-index:2; }
+.pc-badge{ font-size:11px; letter-spacing:.04em; text-transform:uppercase; padding:3px 8px; border-radius:999px; background:var(--badge); color:#fff; box-shadow: var(--shadow); }
+.pc-badge--sale{ background: var(--sale); }
+.pc-badge--new{ background: var(--brand); }
+.pc-badge--best{ background: #333; }
+.pc-badge--oos{ background: var(--muted); }
+
+/* Wishlist */
+.pc__wish{ position:absolute; top:8px; right:8px; z-index:2; background:#fff; border:1px solid var(--border); width:36px; height:36px; border-radius:999px; display:grid; place-items:center; cursor:pointer; }
+.pc__wish[aria-pressed="true"]{ background:var(--brand); color:#fff; border-color:var(--brand); }
+
+/* Body */
+.pc__body{ padding: var(--space-4); display:flex; flex-direction:column; gap:8px; }
+.pc__title{ font-size:14px; margin:0; }
+.pc__rating{ display:flex; align-items:center; gap:6px; color: var(--muted); font-size:12px; }
+.pc__rating-num{ font-variant-numeric: tabular-nums; }
+.pc__price{ display:flex; align-items:baseline; gap:8px; }
+.pc__cta{ margin-top:auto; }
+
+/* Stars (mask technique or inline svg) */
+.pc__rating-stars{ --s:14px; width: calc(var(--s)*5); height: var(--s); display:inline-block; background-repeat:no-repeat; background-size: contain; }
+
+/* Focus visibility */
+.pc:focus-within{ outline:2px solid var(--brand); outline-offset:2px; }
+
+/* Disabled state */
+.pc--oos .pc__atc{ opacity:.6; pointer-events:none; }

--- a/assets/js/home-page.js
+++ b/assets/js/home-page.js
@@ -62,7 +62,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const featured = document.getElementById('featured-products');
     if (featured) {
       const row = document.createElement('div');
-      row.className = 'row';
+      row.className = 'product-grid';
       let items = products.filter(p => (p.tags || []).includes('featured'));
       if (!items.length) items = products.slice(0,8);
       const rendered=[];

--- a/assets/js/product-card.js
+++ b/assets/js/product-card.js
@@ -1,0 +1,140 @@
+// exports: renderProductCard(item), formatPrice(number, currency)
+(function(global){
+  const WISHLIST_KEY = 'wishlist_ids_v1';
+
+  function loadWishlist(){
+    try{ return JSON.parse(localStorage.getItem(WISHLIST_KEY) || '[]'); }catch{ return []; }
+  }
+  function saveWishlist(arr){ localStorage.setItem(WISHLIST_KEY, JSON.stringify(arr)); }
+  function inWishlist(id){ return loadWishlist().includes(String(id)); }
+  function toggleWishlist(id){
+    const idStr = String(id);
+    let list = loadWishlist();
+    if(list.includes(idStr)) list = list.filter(x=>x!==idStr); else list.push(idStr);
+    saveWishlist(list);
+    return list.includes(idStr);
+  }
+
+  function formatPrice(n, currency='PKR'){
+    try{
+      return new Intl.NumberFormat(undefined, { style:'currency', currency }).format(n);
+    }catch{
+      // fallback
+      return (currency + ' ' + (n||0).toLocaleString());
+    }
+  }
+
+  function starsSVG(value){
+    // returns inline SVG string for 0..5 with halves
+    const v = Math.max(0, Math.min(5, Number(value)||0));
+    const full = Math.floor(v);
+    const half = v - full >= 0.5 ? 1 : 0;
+    const empty = 5 - full - half;
+    const icon = (type)=>`<svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="${type}"/></svg>`;
+    const PATH_FULL = "M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.62L12 2 9.19 8.62 2 9.24l5.46 4.73L5.82 21z";
+    const PATH_HALF = "M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.62L12 2v15.27z"; // half star
+    const PATH_EMPTY= "M22 9.24l-7.19-.62L12 2 9.19 8.62 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.64-7.03L22 9.24zm-10 6.11-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 3.89 4.38.38-3.32 2.88 1 4.28L12 15.35z";
+    return [
+      ...Array(full).fill(icon(PATH_FULL)),
+      ...Array(half).fill(icon(PATH_HALF)),
+      ...Array(empty).fill(icon(PATH_EMPTY))
+    ].join('');
+  }
+
+  function renderProductCard(raw){
+    // Accept multiple shapes; normalize to a single item schema
+    const item = normalize(raw);
+
+    const badges = [];
+    if(item.is_oos) badges.push('<span class="pc-badge pc-badge--oos">Out of stock</span>');
+    if(item.is_new) badges.push('<span class="pc-badge pc-badge--new">New</span>');
+    if(item.is_best) badges.push('<span class="pc-badge pc-badge--best">Best</span>');
+    if(item.price.old && item.price.current < item.price.old) badges.push('<span class="pc-badge pc-badge--sale">Sale</span>');
+
+    const wishPressed = inWishlist(item.id);
+    const priceNew = formatPrice(item.price.current, item.price.currency);
+    const priceOld = item.price.old ? formatPrice(item.price.old, item.price.currency) : '';
+
+    const oosClass = item.is_oos ? ' pc--oos' : '';
+    const atcLabel = item.is_oos ? 'Notify Me' : 'Add to Cart';
+
+    return `
+      <article class="pc card-soft${oosClass}" data-id="${item.id}">
+        <a class="pc__link" href="${item.url}" aria-label="${escapeHtml(item.title)}"></a>
+
+        <div class="pc__media aspect-1x1">
+          <img class="pc__img" src="${item.image}" alt="${escapeHtml(item.image_alt || item.title)}" loading="lazy">
+          ${item.image_alt2 ? `<img class="pc__img--alt" src="${item.image_alt2}" alt="" aria-hidden="true" loading="lazy">` : ''}
+          <div class="pc__badges">${badges.join('')}</div>
+          <button class="pc__wish" aria-label="Add to wishlist" aria-pressed="${wishPressed}" data-id="${item.id}">♥</button>
+        </div>
+
+        <div class="pc__body">
+          <h3 class="pc__title clamp-2">${escapeHtml(item.title)}</h3>
+          <div class="pc__rating" aria-label="${item.rating.value} out of 5 stars">
+            <span class="pc__rating-stars" aria-hidden="true">${starsSVG(item.rating.value)}</span>
+            <span class="pc__rating-num">${item.rating.value.toFixed(1)}</span>
+            <span class="pc__rating-count">(${item.rating.count})</span>
+          </div>
+          <div class="pc__price">
+            <span class="price price--new">${priceNew}</span>
+            ${priceOld ? `<span class="price price--old">${priceOld}</span>` : ''}
+          </div>
+          <div class="pc__cta">
+            <button class="btn-modern btn-modern--primary pc__atc" data-id="${item.id}">${atcLabel}</button>
+          </div>
+        </div>
+      </article>
+    `;
+  }
+
+  // Map existing repo data shapes to the unified schema
+  function normalize(raw){
+    // Try common keys from storefront-runtime / search
+    const id = raw.id || raw.item_id || raw.sku || raw.handle || raw.slug || raw._id;
+    const url = raw.url || raw.item_url || (raw.handle ? '/p/'+raw.handle+'/' : raw.slug ? '/p/'+raw.slug+'/' : '#');
+    return {
+      id: String(id||''),
+      url,
+      title: raw.title || raw.name || 'Untitled',
+      image: raw.image || raw.item_image || (raw.images && raw.images[0]) || '',
+      image_alt: raw.image_alt || raw.alt || raw.title || '',
+      image_alt2: raw.image_alt2 || (raw.images && raw.images[1]) || '',
+      is_new: !!(raw.is_new || raw.tags?.includes?.('new')),
+      is_best: !!(raw.is_best || raw.tags?.includes?.('bestseller')),
+      is_oos: !!(raw.is_oos === true || raw.stock === 0 || raw.available === false),
+      rating: {
+        value: Number(raw.rating?.value ?? raw.rating ?? 0) || 0,
+        count: Number(raw.rating?.count ?? raw.reviews ?? 0) || 0
+      },
+      price: {
+        current: Number(raw.price?.current ?? raw.price ?? raw.salePrice ?? 0) || 0,
+        old: raw.price?.old ?? raw.compareAt ?? raw.mrp ?? null,
+        currency: raw.price?.currency || raw.currency || 'PKR'
+      }
+    };
+  }
+
+  function escapeHtml(s){ return String(s||'').replace(/[&<>"']/g, m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;' }[m])); }
+
+  // delegate wishlist/atc events at document level (cards are dynamic)
+  document.addEventListener('click', (e)=>{
+    const wish = e.target.closest('.pc__wish');
+    if(wish){
+      e.preventDefault(); e.stopPropagation();
+      const id = wish.getAttribute('data-id');
+      const state = toggleWishlist(id);
+      wish.setAttribute('aria-pressed', state ? 'true' : 'false');
+      return;
+    }
+    const atc = e.target.closest('.pc__atc');
+    if(atc){
+      const id = atc.getAttribute('data-id');
+      const evt = new CustomEvent('product:addToCart', { detail: { id }, bubbles:true });
+      atc.dispatchEvent(evt);
+    }
+  });
+
+  // expose
+  global.ProductCard = { renderProductCard, formatPrice };
+})(window);

--- a/assets/js/ui-cards.js
+++ b/assets/js/ui-cards.js
@@ -127,3 +127,38 @@ export function buildProductCard(prod) {
 // expose helpers globally
 window.Analytics = Analytics;
 window.showAddedToast = showAddedToast;
+
+// --- appended modern product card integration ---
+// Override buildProductCard to use ProductCard component
+buildProductCard = function(prod){
+  if (!prod || !prod.name || !prod.slug) {
+    console.warn('Invalid product skipped', prod);
+    return null;
+  }
+  const tmp = document.createElement('template');
+  tmp.innerHTML = window.ProductCard.renderProductCard(prod).trim();
+  const el = tmp.content.firstElementChild;
+  if(!el) return null;
+
+  // analytics: product selection
+  const link = el.querySelector('.pc__link');
+  link?.addEventListener('click', () => Analytics.selectItem(prod));
+
+  // cart and analytics on add to cart
+  const priceNum = normalizePrice(prod.price);
+  el.addEventListener('product:addToCart', () => {
+    try{
+      if(typeof simpleCart !== 'undefined' && priceNum !== null){
+        simpleCart.add({
+          id: prod.id || prod.slug,
+          name: prod.name,
+          price: priceNum,
+          quantity: 1
+        });
+      }
+    }catch(e){ console.warn('cart error', e); }
+    Analytics.addToCart(prod, 1);
+    showAddedToast(prod.name);
+  });
+  return el;
+};

--- a/c/index.html
+++ b/c/index.html
@@ -17,6 +17,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
   <link rel="stylesheet" href="/assets/css/custom.css">
   <link rel="stylesheet" href="/assets/css/theme.css">
+  <link rel="stylesheet" href="/assets/css/product-card.css">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to main content</a>
@@ -121,6 +122,7 @@
   <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/config.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
+  <script src="/assets/js/product-card.js"></script>
   <script type="module" src="/assets/js/ui-cards.js"></script>
   <script type="module" src="/assets/js/category-page.js"></script>
   <script src="/assets/js/header-drawer.js"></script>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
   <link rel="stylesheet" href="./assets/css/custom.css">
   <link rel="stylesheet" href="./assets/css/theme.css">
+  <link rel="stylesheet" href="./assets/css/product-card.css">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to main content</a>
@@ -169,6 +170,7 @@
   <script src="./assets/js/config.js"></script>
   <script type="module" src="./assets/js/analytics/index.js"></script>
   <script src="./assets/js/storefront-runtime.js"></script>
+  <script src="./assets/js/product-card.js"></script>
   <script src="./assets/js/footer.js"></script>
   <script type="module" src="./assets/js/ui-cards.js"></script>
   <script type="module" src="./assets/js/home-page.js"></script>

--- a/sandbox/cards.html
+++ b/sandbox/cards.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Product Card Demo</title>
+  <link rel="stylesheet" href="/assets/css/tokens.css">
+  <link rel="stylesheet" href="/assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="/assets/css/custom.css">
+  <link rel="stylesheet" href="/assets/css/theme.css">
+  <link rel="stylesheet" href="/assets/css/product-card.css">
+</head>
+<body>
+  <div class="container py-4">
+    <div class="product-grid" id="demo-grid"></div>
+  </div>
+  <script src="/assets/js/product-card.js"></script>
+  <script>
+    const SAMPLE = [
+      {id:'1', title:'Red Lipstick', url:'#', image:'https://picsum.photos/seed/p1/400', image_alt2:'https://picsum.photos/seed/p1b/400', rating:{value:4.5,count:120}, price:{current:1200, old:1500, currency:'PKR'}, is_new:true},
+      {id:'2', title:'Skin Cream', url:'#', image:'https://picsum.photos/seed/p2/400', rating:{value:3.2,count:10}, price:{current:900, currency:'PKR'}, is_best:true},
+      {id:'3', title:'Perfume', url:'#', image:'https://picsum.photos/seed/p3/400', image_alt2:'https://picsum.photos/seed/p3b/400', rating:{value:5,count:50}, price:{current:5000, old:6000, currency:'PKR'}, is_best:true},
+      {id:'4', title:'Brush Set', url:'#', image:'https://picsum.photos/seed/p4/400', rating:{value:4,count:0}, price:{current:2000, currency:'PKR'}, is_oos:true},
+      {id:'5', title:'Mascara', url:'#', image:'https://picsum.photos/seed/p5/400', rating:{value:2.5,count:4}, price:{current:800, old:1000, currency:'PKR'}},
+      {id:'6', title:'Nail Polish', url:'#', image:'https://picsum.photos/seed/p6/400', rating:{value:3.8,count:22}, price:{current:300, currency:'PKR'}, is_new:true, is_best:true},
+      {id:'7', title:'Foundation', url:'#', image:'https://picsum.photos/seed/p7/400', rating:{value:4.9,count:88}, price:{current:2500, currency:'PKR'}},
+      {id:'8', title:'Serum', url:'#', image:'https://picsum.photos/seed/p8/400', rating:{value:3.5,count:17}, price:{current:1800, old:2100, currency:'PKR'}, is_oos:true}
+    ];
+    const grid = document.getElementById('demo-grid');
+    SAMPLE.forEach(item=>{
+      grid.innerHTML += ProductCard.renderProductCard(item);
+    });
+  </script>
+</body>
+</html>

--- a/search/index.html
+++ b/search/index.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
   <link rel="stylesheet" href="/assets/css/custom.css">
   <link rel="stylesheet" href="/assets/css/theme.css">
+  <link rel="stylesheet" href="/assets/css/product-card.css">
 </head>
 <body>
   <header class="site-header header-compact">
@@ -96,6 +97,7 @@
   <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/config.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
+  <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/search.js"></script>
   <script type="module" src="/assets/js/ui-cards.js"></script>
   <script type="module" src="/assets/js/search-page.js"></script>


### PR DESCRIPTION
## Summary
- add modern product card component with wishlist, ratings, badges, and price formatting
- switch ui-cards helper to render new component and keep analytics/cart handling
- wire product card styles/scripts into product grids and add demo page

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static` *(fails: Link issues: unknown category links)*


------
https://chatgpt.com/codex/tasks/task_e_68a775a652788320bf9e493dd7e81f52