### PR TITLE
Remove account link from headers

### DIFF
--- a/c/index.html
+++ b/c/index.html
@@ -27,7 +27,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>

--- a/cart.html
+++ b/cart.html
@@ -27,7 +27,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>

--- a/categories/index.html
+++ b/categories/index.html
@@ -26,7 +26,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>

--- a/p/index.html
+++ b/p/index.html
@@ -28,7 +28,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>

--- a/search/index.html
+++ b/search/index.html
@@ -28,7 +28,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>


### PR DESCRIPTION
## Summary
- remove account icon and link from site header across pages since no account feature exists

## Testing
- `npm run lint:static` *(fails: unknown links including wishlist)*
- `npm run test:meta` *(fails: missing libatk-1.0.so.0 for Puppeteer)*
- `npm run test:sitemap`
- `npm run test:spa` *(fails: missing libatk-1.0.so.0 for Puppeteer)*
- `npm run test:lighthouse` *(fails: CHROME_PATH not set)*
- `npm run test:features` *(fails: missing libatk-1.0.so.0 for Puppeteer)*

------
https://chatgpt.com/codex/tasks/task_e_68a7988a38088320a31968db95b722e6