### PR TITLE
Enable wishlist on product page

### DIFF
--- a/assets/js/pdp-hydrate.js
+++ b/assets/js/pdp-hydrate.js
@@ -153,6 +153,29 @@
     });
   }
 
+  function wireWishlist(p){
+    var btn = document.querySelector('[data-wishlist]');
+    if(!btn) return;
+    var KEY = 'wishlist_ids_v1';
+    function load(){ try{ return JSON.parse(localStorage.getItem(KEY) || '[]'); }catch(_){ return []; } }
+    function save(arr){ localStorage.setItem(KEY, JSON.stringify(arr)); }
+    function inList(){ return load().includes(String(p.id || p.slug)); }
+    function toggle(){
+      var idStr = String(p.id || p.slug);
+      var list = load();
+      if(list.includes(idStr)) list = list.filter(function(x){ return x!==idStr; }); else list.push(idStr);
+      save(list);
+      return list.includes(idStr);
+    }
+    function sync(){
+      var state = inList();
+      btn.setAttribute('aria-pressed', state ? 'true' : 'false');
+      btn.textContent = state ? 'Remove from Wishlist' : 'Add to Wishlist';
+    }
+    btn.addEventListener('click', function(){ toggle(); sync(); });
+    sync();
+  }
+
   async function hydrate(){
     var p = window.__CURRENT_PRODUCT__ || null;
     if (!p){
@@ -173,6 +196,7 @@
     renderPrice(p);
     renderRating(p);
     wireATC(p);
+    wireWishlist(p);
   }
 
   hydrate();

--- a/assets/js/pdp.js
+++ b/assets/js/pdp.js
@@ -51,6 +51,35 @@
     btn.addEventListener('click', ()=> addToCart(1));
   });
 
+  // Wishlist button
+  const WISHLIST_KEY = 'wishlist_ids_v1';
+  function loadWishlist(){
+    try{ return JSON.parse(localStorage.getItem(WISHLIST_KEY) || '[]'); }catch{ return []; }
+  }
+  function saveWishlist(arr){ localStorage.setItem(WISHLIST_KEY, JSON.stringify(arr)); }
+  function inWishlist(id){ return loadWishlist().includes(String(id)); }
+  function toggleWishlist(id){
+    const idStr = String(id);
+    let list = loadWishlist();
+    if(list.includes(idStr)) list = list.filter(x=>x!==idStr); else list.push(idStr);
+    saveWishlist(list);
+    return list.includes(idStr);
+  }
+  const wishBtn = document.querySelector('[data-wishlist]');
+  const pid = product.id || product.slug;
+  if(wishBtn && pid){
+    function sync(){
+      const state = inWishlist(pid);
+      wishBtn.setAttribute('aria-pressed', state ? 'true' : 'false');
+      wishBtn.textContent = state ? 'Remove from Wishlist' : 'Add to Wishlist';
+    }
+    wishBtn.addEventListener('click', ()=>{
+      toggleWishlist(pid);
+      sync();
+    });
+    sync();
+  }
+
   // Tabs
   const tabs = document.querySelectorAll('[data-tab]');
   const panels = document.querySelectorAll('[data-panel]');

--- a/p/index.html
+++ b/p/index.html
@@ -56,7 +56,7 @@
         <ul class="pdp__bullets">{{ bullets }}</ul>
         <div class="pdp__cta">
           <button class="btn-modern btn-modern--primary" data-atc>Add to Cart</button>
-          <button class="btn-modern btn-modern--ghost">Add to Wishlist</button>
+          <button class="btn-modern btn-modern--ghost" data-wishlist aria-pressed="false">Add to Wishlist</button>
         </div>
         <div class="pdp-tabs">
           <nav class="pdp-tabs__nav" role="tablist">


### PR DESCRIPTION
## Summary
- add data-wishlist button on PDP
- persist wishlist state in localStorage and toggle label

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static` *(fails: Link issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a79a2c52688320bd5c983f8535451e