### PR TITLE
Show two products per row on mobile

### DIFF
--- a/assets/css/product-card.css
+++ b/assets/css/product-card.css
@@ -1,6 +1,11 @@
 /* Grid alignment */
 .product-grid{ display:grid; gap: var(--space-5); grid-template-columns: repeat(auto-fill, minmax(190px,1fr)); }
 
+/* Two columns on small screens */
+@media (max-width: 640px){
+  .product-grid{ grid-template-columns: repeat(2, 1fr); }
+}
+
 /* Card basics */
 .pc{ position:relative; display:flex; flex-direction:column; overflow:hidden; }
 .pc__link{ position:absolute; inset:0; z-index:1; }


### PR DESCRIPTION
## Summary
- force product grid into two columns on small screens for better mobile layout

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static` *(reports broken links)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a454351c832099f856218464d003