### PR TITLE
Show two products per row on mobile

### DIFF
--- a/assets/css/bonanza-layout.css
+++ b/assets/css/bonanza-layout.css
@@ -17,6 +17,9 @@
 .bnz-tab.is-active{ background:#111; color:#fff; }
 .bnz-main{ padding:28px 0 40px; }
 .product-grid{ grid-template-columns:repeat(auto-fill,minmax(260px,1fr)); gap:36px 28px; }
+@media (max-width:640px){
+  .product-grid{ grid-template-columns:repeat(2,1fr); gap:var(--space-5); }
+}
 .pc.card-soft{ border-color:#e9e9e9; border-radius:0; box-shadow:none; }
 .pc__body{ padding:12px 0 0; }
 .pc__title{ font-size:13px; letter-spacing:.02em; text-transform:uppercase; color:#111; }

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -293,7 +293,7 @@ body.drawer-open{
   gap:var(--space-4);
 }
 @media (max-width:400px){
-  .product-grid{grid-template-columns:1fr;}
+  .product-grid{grid-template-columns:repeat(2,1fr);}
 }
 @media (min-width:768px){
   .product-grid{grid-template-columns:repeat(3,1fr);}

--- a/assets/css/product-card.css
+++ b/assets/css/product-card.css
@@ -1,6 +1,11 @@
 /* Grid alignment */
 .product-grid{ display:grid; gap: var(--space-5); grid-template-columns: repeat(auto-fill, minmax(190px,1fr)); }
 
+/* Two columns on small screens */
+@media (max-width: 640px){
+  .product-grid{ grid-template-columns: repeat(2, 1fr); }
+}
+
 /* Card basics */
 .pc{ position:relative; display:flex; flex-direction:column; overflow:hidden; }
 .pc__link{ position:absolute; inset:0; z-index:1; }


### PR DESCRIPTION
## Summary
- adjust custom and bonanza layout styles so product grid uses two columns on small screens

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static` *(reports broken link warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a454351c832099f856218464d003