### PR TITLE
feat: add Silkfull Face Serum product

### DIFF
--- a/assets/data/products.json
+++ b/assets/data/products.json
@@ -283,5 +283,27 @@
     "descriptionHTML": "<p>Roseberry Branded Makeup kit \"Eyeshadow Palette\", \"Blush highlighter palette\", \"Concealer\", \"3 lipsticks\", \"3 lipgloss\",\"1 liquid blush\" available in makeup kit</p>",
     "inStock": true,
     "sku": "KIT001"
+  },
+  {
+    "id": "SKN001",
+    "name": "Silkfull Face Serum",
+    "slug": "silkfull-face-serum",
+    "images": [
+      "/assets/img/products/IMG-20250820-WA0204.jpg"
+    ],
+    "price": 2350,
+    "currency": "PKR",
+    "categories": [
+      "skin-care",
+      "serums"
+    ],
+    "brand": "Silkfull",
+    "tags": [
+      "skincare"
+    ],
+    "shortDescription": "Nourishing whitening serum brightens skin, reduces dark spots, and evens tone.",
+    "descriptionHTML": "<p>Nourishing and smoothing whitening serum for brightening skin, eliminating dark spots, and evening out skin tone, suitable for day and night use, with natural ingredients.</p>",
+    "inStock": true,
+    "sku": "SKN001"
   }
 ]


### PR DESCRIPTION
## Summary
- add Silkfull Face Serum to product catalog

## Testing
- `npm run validate:data`
- `npm run lint:static`
- `npm run test:meta` *(fails: libatk-1.0.so.0 missing)*
- `npm run test:sitemap` *(fails: missing URLs /p/roseberry-concealer, /p/sheglam-compact-powder, /p/roseberry-make-up-kit, /p/silkfull-face-serum)*
- `npm run test:spa` *(fails: libatk-1.0.so.0 missing)*
- `npm run test:lighthouse` *(fails: CHROME_PATH not set)*
- `npm run test:features` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac39e52a948320bd4a4bcc555189d1