### PR TITLE
Show all categories in nav tabs

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -66,27 +66,25 @@ a:hover{color:var(--brand-600); text-decoration:underline}
 .drawer-links{display:flex;flex-direction:column;gap:12px;font-size:16px}
 .drawer-search input{margin-top:12px;border-radius:999px;border:1px solid var(--border);padding:10px 14px}
 .body-lock{overflow:hidden}
-/* Center the primary category tabs */
+/* Primary category tabs */
 .bnz-tabs{
   display:flex;
   align-items:center;
-  justify-content:center;   /* <-- centers the row */
+  justify-content:flex-start;   /* keep first tabs visible */
   gap:12px;
   width:100%;
   margin:10px auto 18px;
   padding:4px 0;
+  overflow-x:auto;
+  -webkit-overflow-scrolling:touch;
 }
 
 .bnz-tabs__item{
   flex:0 0 auto;            /* prevent stretching */
 }
 
-/* Optional: keep them left-aligned on very small screens with horizontal scroll */
 @media (max-width: 640px){
   .bnz-tabs{
-    justify-content:flex-start;
-    overflow-x:auto;
-    -webkit-overflow-scrolling:touch;
     padding:4px 12px;
   }
   .bnz-tabs__item{ scroll-snap-align:center; }

--- a/assets/js/tabs.js
+++ b/assets/js/tabs.js
@@ -43,13 +43,8 @@
     const slug = c.slug || c.handle || (name||'').toLowerCase().trim().replace(/[^a-z0-9]+/g,'-').replace(/^-+|-+$/g,'');
     const url  = c.url || c.href || `/c/${slug}/`;
     const parent = c.parent_id ?? c.parent ?? c.parentId ?? null;
-    const order = c.order ?? c.position ?? c.sort ?? 0;
+    const order = c.order ?? c.position ?? c.sort ?? c.sortOrder ?? 0;
     return { id: c.id || slug, name, slug, url, parent, order };
-  }
-
-  function isTopLevel(c){
-    // treat null/undefined/0/'' as top-level
-    return c.parent == null || c.parent === 0 || c.parent === '' || c.parent === 'root';
   }
 
   function uniqueBy(arr, key){
@@ -77,12 +72,10 @@
 
     // optional "All" tab pointing to home (matches reference)
     const allTab = { id:'__all', name:'Beauty', url: '/', order: -1, parent:null };
-    const tops = cats.filter(isTopLevel).map(normalize);
-    const uniq = uniqueBy(tops, 'slug').sort((a,b)=> (a.order||0) - (b.order||0) || a.name.localeCompare(b.name));
+    const normalized = cats.map(normalize);
+    const uniq = uniqueBy(normalized, 'slug').sort((a,b)=> (a.order||0) - (b.order||0) || a.name.localeCompare(b.name));
 
-    // Limit to 6–8 like the reference; you can increase if needed.
-    const limited = uniq.slice(0, 8);
-    const items = [allTab, ...limited];
+    const items = [allTab, ...uniq];
 
     // Render
     nav.innerHTML = items.map(it => `


### PR DESCRIPTION
## Summary
- Render every category from categories.json in the primary navigation
- Preserve category ordering via `sortOrder`
- Left-align tabs to keep initial categories visible

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint:static` *(broken links reported)*

------
https://chatgpt.com/codex/tasks/task_e_68ad91bbab648320976f223ee0faf2c6