### PR TITLE
Remove checkout page link and rely on cart-only checkout

### DIFF
--- a/assets/js/cart-ui.js
+++ b/assets/js/cart-ui.js
@@ -207,14 +207,8 @@
       const sel = document.querySelector('input[name="pm"]:checked');
       const method = sel ? sel.value : 'cod';
       localStorage.setItem('checkout_pm', method);
-      // If your site has /checkout.html, go there; else show a basic confirmation
-      try{
-        // check existence by attempting to fetch HEAD quickly (non-blocking in static env, so just navigate)
-        window.location.href = '/checkout.html';
-      }catch(_){
-        const note = document.getElementById('checkout-notes');
-        if (note) note.textContent = `Selected payment method: ${method.toUpperCase()}.`;
-      }
+      const note = document.getElementById('checkout-notes');
+      if (note) note.textContent = `Selected payment method: ${method.toUpperCase()}.`;
     }
   });
 

--- a/cart.html
+++ b/cart.html
@@ -45,7 +45,6 @@
     <aside class="cart-summary">
       <div class="row"><span>Subtotal</span><span id="cart-subtotal">—</span></div>
       <div class="row total"><span>Total</span><span id="cart-total">See checkout</span></div>
-      <a href="/checkout.html" class="btn btn-outline-dark w-100 mt-2">Proceed to Checkout</a>
     </aside>
   </main>
   


### PR DESCRIPTION
## Summary
- Remove link to non-existent checkout page and keep checkout within cart.
- Keep cart summary and ensure cart-ui script loads for single-page checkout.
- Update cart-ui checkout handler to avoid redirecting to missing checkout page and instead confirm the selected payment method on the cart page.

## Testing
- `npm test` (fails: no test specified)
- `npm run lint:static` (broken link reports)
- `npm run test:meta` (fails: libatk-1.0.so.0 missing)
- `npm run test:sitemap` (missing URLs reported)
- `npm run test:spa` (fails: libatk-1.0.so.0 missing)
- `npm run test:lighthouse` (fails: ChromePathNotSetError)
- `npm run test:features` (fails: libatk-1.0.so.0 missing)


------
https://chatgpt.com/codex/tasks/task_e_68ad9ca817d083208d8fa47879759f8c