### PR TITLE
Add WhatsApp COD payment adapter

### DIFF
--- a/assets/js/cart-ui.js
+++ b/assets/js/cart-ui.js
@@ -77,6 +77,7 @@
           <label class="pm-option"><input type="radio" name="pm" value="nift"> NIFT ePay</label>
           <label class="pm-option"><input type="radio" name="pm" value="bank"> Bank Transfer</label>
           <label class="pm-option"><input type="radio" name="pm" value="cod"> Cash on Delivery</label>
+          <label class="pm-option"><input type="radio" name="pm" value="whatsappCod"> WhatsApp (Cash on Delivery)</label>
           <small class="pm-note">All transactions are charged in PKR.</small>
         </div>
         <div id="pm-feedback" class="pm-feedback" role="status" aria-live="polite"></div>

--- a/assets/js/payments.js
+++ b/assets/js/payments.js
@@ -109,6 +109,37 @@ export const Payments = {
       const mailto = `mailto:${cfg.mailto}?subject=${encodeURIComponent('COD - '+order.id)}&body=${encodeURIComponent(body)}`;
       return { mailto };
     }
+  },
+  whatsappCod: {
+    needsServer:false,
+    async start(order){
+      const raw = (document.documentElement?.dataset?.whatsapp || window.__SHOP_WHATSAPP__ || '').replace(/\D/g,'');
+      const lines = [];
+      lines.push('New COD Order');
+      if(order.buyer){
+        lines.push('');
+        if(order.buyer.name) lines.push(`Name: ${order.buyer.name}`);
+        if(order.buyer.phone) lines.push(`Phone: ${order.buyer.phone}`);
+        if(order.buyer.address) lines.push(`Address: ${order.buyer.address}`);
+        if(order.buyer.city) lines.push(`City: ${order.buyer.city}`);
+      }
+      lines.push('');
+      if(order.id) lines.push(`Order ID: ${order.id}`);
+      lines.push(`Subtotal: ${fmt(order.subtotal, order.currency)}`);
+      if(order.shipping) lines.push(`Shipping: ${fmt(order.shipping, order.currency)}`);
+      lines.push(`Total: ${fmt(order.amount, order.currency)}`);
+      lines.push('');
+      lines.push('Items:');
+      lines.push(order.items.map(i=>{
+        const qty = i.qty || i.quantity || 1;
+        const title = i.name || i.title;
+        const price = fmt(i.subtotal || (i.unit * qty) || i.unit || 0, order.currency);
+        return `• ${title} × ${qty} — ${price}`;
+      }).join('\n'));
+      const message = lines.join('\n');
+      const redirectUrl = `https://wa.me/${raw}?text=${encodeURIComponent(message)}`;
+      return { redirectUrl };
+    }
   }
 };
 

--- a/payments-config.json
+++ b/payments-config.json
@@ -78,6 +78,10 @@
       "type": "offline",
       "mode": "mailto",
       "mailto": "orders@4dcosmetics.com"
+    },
+    "whatsappCod": {
+      "type": "offline",
+      "mode": "redirect"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add `whatsappCod` payment adapter to send order summary via WhatsApp
- expose WhatsApp COD method in config and checkout UI

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static` *(fails: broken link errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9ff2d1888320b08f4c6ab22a1684