### PR TITLE
Persist last order and show receipt on redirect

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -37,9 +37,14 @@ const Checkout = {
 
     try{
       const res = await adapter.start(ord, providerCfg, returnUrls);
+      ord.id = ord.id || (`ORD-${Date.now()}`);
       localStorage.setItem('4d-last-order', JSON.stringify(ord));
       if(res.redirectUrl){
-        window.location = res.redirectUrl;
+        const successUrl = (this.config && this.config.returnUrls && this.config.returnUrls.success)
+          ? `${this.config.returnUrls.success}?oid=${encodeURIComponent(ord.id)}`
+          : `/thank-you.html?oid=${encodeURIComponent(ord.id)}`;
+        window.open(res.redirectUrl, '_blank');
+        window.location.href = successUrl;
       } else if(res.action && res.fields){
         const f = document.createElement('form');
         f.method='POST'; f.action = res.action;


### PR DESCRIPTION
## Summary
- Ensure checkout assigns an order ID and saves it to localStorage before any redirect
- Open provider redirects (e.g., WhatsApp COD) in a new tab and immediately send current tab to thank-you page

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static` *(fails: link issues; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68ada1c2e6f88320983b10bf1a8f93fa