### PR TITLE
feat: add WhatsApp order CTA on product page

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -32,6 +32,8 @@ a:hover{color:var(--brand-600); text-decoration:underline}
 .btn-modern--primary{background:var(--brand); color:#fff}
 .btn-modern--primary:hover{background:var(--brand-600)}
 .btn-modern--ghost{background:#fff;border-color:var(--border);color:var(--text)}
+.btn-modern--whatsapp{background:#25D366;color:#fff}
+.btn-modern--whatsapp:hover{background:#1EBE57}
 .badge-chip{display:inline-block; padding:2px 8px; border-radius:999px; font-size:12px; text-transform:uppercase; letter-spacing:.04em}
 .price{font-weight:600}
 .price--old{color:var(--muted); text-decoration:line-through; margin-left:8px; font-weight:400}

--- a/assets/js/pdp-hydrate.js
+++ b/assets/js/pdp-hydrate.js
@@ -176,6 +176,29 @@
     sync();
   }
 
+  function getSelectedVariant(){
+    var el = document.querySelector('.variant-swatch.selected') || document.querySelector('.variant-swatch[aria-pressed="true"]') || document.querySelector('select[name="variant"] option:checked') || document.querySelector('input[name="variant"]:checked');
+    if(!el) return '';
+    return el.getAttribute('aria-label') || el.title || el.textContent || el.value || '';
+  }
+
+  function wireWhatsApp(p){
+    document.querySelectorAll('[data-wa-order]').forEach(function(btn){
+      btn.addEventListener('click', function(){
+        var raw = (document.documentElement?.dataset?.whatsapp || window.__SHOP_WHATSAPP__ || '').replace(/\D/g,'');
+        if(!raw) return;
+        var variant = getSelectedVariant();
+        var lines = [];
+        lines.push(p.title || p.name || '');
+        if(variant) lines[0] += ' - ' + variant;
+        lines.push(location.href);
+        lines.push("I'd like to order via Cash on Delivery.");
+        var waUrl = 'https://wa.me/' + raw + '?text=' + encodeURIComponent(lines.join('\n'));
+        window.open(waUrl, '_blank');
+      });
+    });
+  }
+
   async function hydrate(){
     var p = window.__CURRENT_PRODUCT__ || null;
     if (!p){
@@ -197,6 +220,7 @@
     renderRating(p);
     wireATC(p);
     wireWishlist(p);
+    wireWhatsApp(p);
   }
 
   hydrate();

--- a/p/index.html
+++ b/p/index.html
@@ -57,6 +57,7 @@
         <ul class="pdp__bullets">{{ bullets }}</ul>
         <div class="pdp__cta">
           <button class="btn-modern btn-modern--primary" data-atc>Add to Cart</button>
+          <button class="btn-modern btn-modern--whatsapp" data-wa-order>Order via WhatsApp</button>
           <button class="btn-modern btn-modern--ghost" data-wishlist aria-pressed="false">Add to Wishlist</button>
         </div>
         <div class="pdp-tabs">
@@ -75,6 +76,7 @@
     </section>
     <div class="mobile-atc">
       <button class="btn-modern btn-modern--primary" data-atc>Add to Cart</button>
+      <button class="btn-modern btn-modern--whatsapp" data-wa-order>Order via WhatsApp</button>
       <div class="mobile-atc__price" id="mobile-atc-price"></div>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- add "Order via WhatsApp" button alongside Add to Cart on product pages
- style WhatsApp CTA and wire it to open chat with product details prefilled

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:static` (reports existing broken links)


------
https://chatgpt.com/codex/tasks/task_e_68ada29124dc8320832c1dab2acdfe8f