### PR TITLE
style: refine checkout buyer form

### DIFF
--- a/assets/css/checkout.css
+++ b/assets/css/checkout.css
@@ -1,3 +1,30 @@
 .pm-option{display:block;margin:var(--space-1) 0;}
 .pm-feedback{margin-top:var(--space-2);color:var(--danger);}
 .checkout-notes{margin-top:var(--space-2);font-size:var(--font-size-200);color:var(--muted);}
+
+/* Checkout form sections */
+.pm-section{
+  margin-top: var(--space-4);
+}
+
+#buyer-name,
+#buyer-phone,
+#buyer-address,
+#buyer-city,
+#checkout-notes{
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--text);
+}
+
+#buyer-name:focus,
+#buyer-phone:focus,
+#buyer-address:focus,
+#buyer-city:focus,
+#checkout-notes:focus{
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}

--- a/assets/js/cart-ui.js
+++ b/assets/js/cart-ui.js
@@ -52,7 +52,7 @@
         <div class="progress"><div id="fs-bar" class="progress-bar" style="width:0%"></div></div>
       </div>
 
-      <section id="buyer-details" aria-labelledby="bd-title" class="pm-section">
+      <section id="buyer-details" aria-labelledby="bd-title" class="pm-section card">
         <h2 id="bd-title">Buyer details</h2>
         <label for="buyer-name">Full Name</label>
         <input id="buyer-name" type="text" required placeholder="Your name">
@@ -66,7 +66,7 @@
         <textarea id="checkout-notes" placeholder="Any delivery instructions"></textarea>
       </section>
 
-      <section id="payment-methods" aria-labelledby="pm-title" class="pm-section">
+      <section id="payment-methods" aria-labelledby="pm-title" class="pm-section card">
         <h2 id="pm-title">Payment method</h2>
         <div class="pm-options" role="radiogroup" aria-label="Payment methods">
           <label class="pm-option"><input type="radio" name="payment-method" value="whatsappCod" ${defaultPM === 'whatsappCod' ? 'checked' : ''}> WhatsApp (Cash on Delivery)</label>


### PR DESCRIPTION
## Summary
- style checkout buyer form fields with theme padding, borders, and focus outline
- apply existing `card` panel styling to buyer and payment sections

## Testing
- `npm run lint:static`

------
https://chatgpt.com/codex/tasks/task_e_68ada3c7fb2c83208232fea546a968ad