### PR TITLE
Load checkout module on cart page

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -86,6 +86,7 @@
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>
+  <script type="module" src="/assets/js/checkout.js"></script>
   <script src="/assets/js/cart-ui.js"></script>
   <script src="/assets/js/whatsapp-fab.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- load checkout module script on cart page before existing cart UI script

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68ada85f86f88320b667cf479ab4f5da