### PR TITLE
Support HTML description and how-to-use aliases

### DIFF
--- a/assets/js/pdp-hydrate.js
+++ b/assets/js/pdp-hydrate.js
@@ -211,9 +211,9 @@
     }
     if(p.brand) setText('.pdp__brand', p.brand); else { var b=document.querySelector('.pdp__brand'); if(b) b.style.display='none'; }
     setText('.pdp__title', p.title || p.name || '');
-    setHTML('[data-panel="desc"]', p.description || '');
+    setHTML('[data-panel="desc"]', p.descriptionHTML || p.description || '');
     setHTML('[data-panel="ingr"]', p.ingredients || '');
-    setHTML('[data-panel="use"]',  p.how_to_use || '');
+    setHTML('[data-panel="use"]',  p.howToUse || p.how_to_use || '');
     renderBullets(p);
     renderGallery(p);
     renderPrice(p);


### PR DESCRIPTION
## Summary
- Use `descriptionHTML` when available for product description
- Check `howToUse` alias for usage instructions

## Testing
- `npm run lint:static` (fails: broken links)
- `npm run validate:data`
- `npm run test:meta` (fails: libatk-1.0.so.0 missing)
- `npm run test:sitemap` (fails: Missing URLs)
- `npm run test:spa` (fails: libatk-1.0.so.0 missing)
- `npm run test:features` (fails: libatk-1.0.so.0 missing)
- `npm run test:lighthouse` (fails: CHROME_PATH not set)


------
https://chatgpt.com/codex/tasks/task_e_68ada88f17f48320940869dae9fcbe51