### PR TITLE
feat: indicate out of stock items

### DIFF
--- a/assets/css/product-card.css
+++ b/assets/css/product-card.css
@@ -45,6 +45,10 @@
 /* Disabled state */
 .pc--oos .pc__atc{ opacity:.6; pointer-events:none; }
 
+/* Dim image when out of stock */
+.pc.is-oos .pc__img,
+.pc.is-oos .pc__img--alt{ opacity:.5; }
+
 /* Improve badge contrast on bright images */
 .pc-badge{
   text-shadow: 0 1px 1px rgba(0,0,0,.25);

--- a/assets/js/pdp-hydrate.js
+++ b/assets/js/pdp-hydrate.js
@@ -44,6 +44,7 @@
     var priceCurrent = (p.price && (p.price.current ?? p.price)) ?? p.salePrice ?? p.min_price ?? p.amount ?? 0;
     var priceOld = p.price?.old ?? p.compareAt ?? p.mrp ?? null;
     var currency = p.price?.currency || p.currency || 'PKR';
+    var oos = p.inStock === false || p.is_oos === true || p.stock === 0 || p.available === false;
     return {
       id: String(p.id || p.slug || p.handle || p._id || ''),
       slug: p.slug || p.handle || norm(p.name || p.title || ''),
@@ -56,7 +57,9 @@
       ingredients: p.ingredients || p.Ingredients || '',
       bullets: p.bullets || p.highlights || p.features || p.bulletPoints || '',
       rating: { value: Number(p.rating?.value ?? p.rating ?? 0) || 0, count: Number(p.rating?.count ?? p.reviews ?? 0) || 0 },
-      price: { current: Number(priceCurrent)||0, old: priceOld, currency: currency }
+      price: { current: Number(priceCurrent)||0, old: priceOld, currency: currency },
+      inStock: !oos,
+      is_oos: oos
     };
   }
 
@@ -141,7 +144,19 @@
   }
 
   function wireATC(p){
-    document.querySelectorAll('[data-atc]').forEach(function(btn){
+    var buttons = document.querySelectorAll('[data-atc]');
+    if(p.inStock === false){
+      buttons.forEach(function(btn){
+        btn.setAttribute('disabled','');
+        btn.setAttribute('aria-disabled','true');
+        btn.textContent = 'Out of stock';
+      });
+      document.querySelectorAll('[data-qty], [data-qty-controls], .qty-controls, .pdp__qty').forEach(function(el){
+        el.style.display = 'none';
+      });
+      return;
+    }
+    buttons.forEach(function(btn){
       btn.addEventListener('click', function(){
         try{
           if(typeof simpleCart !== 'undefined'){

--- a/assets/js/pdp.js
+++ b/assets/js/pdp.js
@@ -2,6 +2,7 @@
   // Expect product data from runtime (adapt if your runtime differs)
   const product = window.Storefront?.getCurrentProduct?.() || window.__CURRENT_PRODUCT__;
   if(!product) return;
+  const outOfStock = product.inStock === false || product.is_oos === true || product.stock === 0 || product.available === false;
 
   // Populate gallery
   const mainBox = document.querySelector('.pdp__main');
@@ -47,9 +48,21 @@
     }catch(e){ console.warn('cart error', e); }
     document.dispatchEvent(new CustomEvent('product:addToCart', { detail:{ id: product.id || product.slug, qty: qty||1 }}));
   }
-  document.querySelectorAll('[data-atc]').forEach(btn=>{
-    btn.addEventListener('click', ()=> addToCart(1));
-  });
+  const atcButtons = document.querySelectorAll('[data-atc]');
+  if(outOfStock){
+    atcButtons.forEach(btn=>{
+      btn.setAttribute('disabled','');
+      btn.setAttribute('aria-disabled','true');
+      btn.textContent = 'Out of stock';
+    });
+    document.querySelectorAll('[data-qty], [data-qty-controls], .qty-controls, .pdp__qty').forEach(el=>{
+      el.style.display = 'none';
+    });
+  }else{
+    atcButtons.forEach(btn=>{
+      btn.addEventListener('click', ()=> addToCart(1));
+    });
+  }
 
   // Wishlist button
   const WISHLIST_KEY = 'wishlist_ids_v1';

--- a/assets/js/product-card.js
+++ b/assets/js/product-card.js
@@ -67,8 +67,10 @@
     const mainImg = item.image || FALLBACK_IMG;
     const imgAlt = item.image ? escapeHtml(item.image_alt || item.title) : 'No image available';
 
+    const outOfStock = item.inStock === false || item.is_oos;
+
     const badges = [];
-    if(item.is_oos) badges.push('<span class="pc-badge pc-badge--oos">Out of stock</span>');
+    if(outOfStock) badges.push('<span class="pc-badge pc-badge--oos">Out of stock</span>');
     if(item.is_new) badges.push('<span class="pc-badge pc-badge--new">New</span>');
     if(item.is_best) badges.push('<span class="pc-badge pc-badge--best">Best</span>');
     if(item.price.old && item.price.current < item.price.old) badges.push('<span class="pc-badge pc-badge--sale">Sale</span>');
@@ -78,9 +80,9 @@
     const priceNew = formatDisplayPrice(item.price.current, item.price.currency);
     const priceOld = item.price.old ? formatDisplayPrice(item.price.old, item.price.currency) : '';
 
-    const oosClass = item.is_oos ? ' pc--oos' : '';
-    const atcLabel = item.is_oos ? 'Notify Me' : 'Add to Cart';
-    const atcAttrs = item.is_oos ? 'aria-disabled="true" title="Out of stock — get notified"' : '';
+    const oosClass = outOfStock ? ' pc--oos is-oos' : '';
+    const atcLabel = outOfStock ? 'Out of stock' : 'Add to Cart';
+    const atcAttrs = outOfStock ? 'aria-disabled="true" disabled title="Out of stock"' : '';
 
     return `
       <article class="pc card-soft${oosClass}" data-id="${item.id}">
@@ -117,6 +119,7 @@
     // Try common keys from storefront-runtime / search
     const id = raw.id || raw.item_id || raw.sku || raw.handle || raw.slug || raw._id;
     const url = raw.url || raw.item_url || (raw.handle ? '/p/'+raw.handle+'/' : raw.slug ? '/p/'+raw.slug+'/' : '#');
+    const oos = raw.inStock === false || raw.is_oos === true || raw.stock === 0 || raw.available === false;
     return {
       id: String(id||''),
       url,
@@ -126,7 +129,8 @@
       image_alt2: raw.image_alt2 || (raw.images && raw.images[1]) || '',
       is_new: !!(raw.is_new || raw.tags?.includes?.('new')),
       is_best: !!(raw.is_best || raw.tags?.includes?.('bestseller')),
-      is_oos: !!(raw.is_oos === true || raw.stock === 0 || raw.available === false),
+      is_oos: oos,
+      inStock: !oos,
       rating: {
         value: Number(raw.rating?.value ?? raw.rating ?? 0) || 0,
         count: Number(raw.rating?.count ?? raw.reviews ?? 0) || 0


### PR DESCRIPTION
## Summary
- show an "Out of stock" badge and dim image on product cards
- disable ATC buttons when products are unavailable
- hide PDP quantity controls for out-of-stock products

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:static` (fails: Link issues in static-site-lint.js)


------
https://chatgpt.com/codex/tasks/task_e_68ada89ea01883208fe27166c926e419