### PR TITLE
refactor: unify WhatsApp FAB link

### DIFF
--- a/assets/js/whatsapp-fab.js
+++ b/assets/js/whatsapp-fab.js
@@ -1,7 +1,7 @@
 (function(){
-  const raw = (document.documentElement.dataset.whatsapp || window.__SHOP_WHATSAPP__ || '').replace(/\D/g,'');
+  const raw = (document.documentElement?.dataset?.whatsapp || window.__SHOP_WHATSAPP__ || '').replace(/\D/g,'');
   if(!raw) return;
-  const href = 'https://wa.me/' + raw;
+  const href = `https://wa.me/${raw}`;
   const a = document.createElement('a');
   a.href = href;
   a.target = '_blank';


### PR DESCRIPTION
## Summary
- read WhatsApp number from document dataset or global variable
- build FAB link with https://wa.me

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run test:meta` (fails: Failed to launch the browser process: libatk-1.0.so.0 missing)


------
https://chatgpt.com/codex/tasks/task_e_68adae490e888320a1dc30dbf3ac3e89