### PR TITLE
refactor: remove unused currency conversion code

### DIFF
--- a/assets/js/cart-page.js
+++ b/assets/js/cart-page.js
@@ -198,8 +198,7 @@ $(function () {
       tax: totals.tax,
       coupon: appliedCoupon || null,
       shippingMethod: null,
-      buyer: null,
-      fx: null
+      buyer: null
     };
     const method = $('input[name="pm"]:checked').val();
     if (window.Checkout && typeof window.Checkout.start === 'function') {

--- a/assets/js/cart-ui.js
+++ b/assets/js/cart-ui.js
@@ -241,8 +241,7 @@
         tax: totals.tax,
         coupon: totals.coupon ? totals.coupon.code : null,
         shippingMethod: null,
-        buyer: null,
-        fx: null
+        buyer: null
       };
 
       const buyer = {

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -1,4 +1,4 @@
-import { Payments, fmt, toPKR } from './payments.js';
+import { Payments, fmt } from './payments.js';
 
 const Checkout = {
   config: null,
@@ -24,11 +24,8 @@ const Checkout = {
       return;
     }
     const fb2 = document.getElementById('checkout-feedback');
-    let ord = order;
-    if(order.currency !== 'PKR'){
-      ord = toPKR(order, this.config.pkConversionRate);
-      if(fb2) fb2.textContent = `Charged in PKR at 1 ${order.currency} = ${this.config.pkConversionRate} PKR (est.).`;
-    } else if(fb2){ fb2.textContent = ''; }
+    const ord = order;
+    if(fb2) fb2.textContent = '';
 
     const returnUrls = {
       successUrl: `${this.config.returnUrls.success}?oid=${encodeURIComponent(ord.id)}&pm=${method}`,

--- a/assets/js/payments.js
+++ b/assets/js/payments.js
@@ -154,17 +154,3 @@ function safeBuyer(b){
   if(b.email) parts.push(b.email);
   return parts.join(' / ') || '—';
 }
-
-export function toPKR(order, rate){
-  const cloned = JSON.parse(JSON.stringify(order));
-  cloned.fx = { base: order.currency, target: 'PKR', rate: rate, baseAmount: order.amount };
-  const convert = (n)=> Math.round(n * rate * 100)/100;
-  cloned.currency = 'PKR';
-  cloned.amount = convert(order.amount);
-  cloned.subtotal = convert(order.subtotal);
-  cloned.discount = convert(order.discount);
-  cloned.shipping = convert(order.shipping);
-  cloned.tax = convert(order.tax);
-  cloned.items = order.items.map(i=>({ ...i, unit: convert(i.unit), subtotal: convert(i.subtotal) }));
-  return cloned;
-}

--- a/payments-config.json
+++ b/payments-config.json
@@ -1,6 +1,5 @@
 {
   "currencyDefault": "PKR",
-  "pkConversionRate": 278.00,
   "sandbox": true,
   "returnUrls": {
     "success": "/thank-you.html",

--- a/thank-you.html
+++ b/thank-you.html
@@ -97,9 +97,6 @@
       if(txn) html += `<p><strong>Reference:</strong> ${txn}</p>`;
       html += '<ul>' + order.items.map(i=>`<li>${i.name} × ${i.quantity} = ${fmt(i.subtotal, order.currency)}</li>`).join('') + '</ul>';
       html += `<p><strong>Total:</strong> ${fmt(order.amount, order.currency)}</p>`;
-      if(order.fx && order.fx.base !== order.currency){
-        html += `<p class="small">Base amount: ${fmt(order.fx.baseAmount, order.fx.base)} (1 ${order.fx.base} = ${order.fx.rate} ${order.fx.target})</p>`;
-      }
       if(pm) html += `<p><strong>Payment method:</strong> ${pm === 'whatsappCod' ? 'WhatsApp COD' : pm}</p>`;
       receipt.innerHTML = html;
     } else {


### PR DESCRIPTION
## Summary
- drop pkConversionRate config and all PKR conversion helpers
- stop building `fx` metadata and `toPKR` conversions
- simplify checkout and thank-you pages without currency conversions

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static`
- `npm run validate:data`


------
https://chatgpt.com/codex/tasks/task_e_68adb05b55ec8320a8fbab22bac19414