### PR TITLE
chore: remove obsolete currency conversion helpers

### DIFF
--- a/assets/js/cart-page.js
+++ b/assets/js/cart-page.js
@@ -198,8 +198,7 @@ $(function () {
       tax: totals.tax,
       coupon: appliedCoupon || null,
       shippingMethod: null,
-      buyer: null,
-      fx: null
+      buyer: null
     };
     const method = $('input[name="pm"]:checked').val();
     if (window.Checkout && typeof window.Checkout.start === 'function') {

--- a/assets/js/cart-ui.js
+++ b/assets/js/cart-ui.js
@@ -240,8 +240,7 @@
         tax: totals.tax,
         coupon: totals.coupon ? totals.coupon.code : null,
         shippingMethod: null,
-        buyer: null,
-        fx: null
+        buyer: null
       };
 
       order.currency = 'PKR';

--- a/assets/js/payments.js
+++ b/assets/js/payments.js
@@ -155,17 +155,3 @@ function safeBuyer(b){
   if(b.email) parts.push(b.email);
   return parts.join(' / ') || '—';
 }
-
-export function toPKR(order, rate){
-  const cloned = JSON.parse(JSON.stringify(order));
-  cloned.fx = { base: order.currency, target: 'PKR', rate: rate, baseAmount: order.amount };
-  const convert = (n)=> Math.round(n * rate * 100)/100;
-  cloned.currency = 'PKR';
-  cloned.amount = convert(order.amount);
-  cloned.subtotal = convert(order.subtotal);
-  cloned.discount = convert(order.discount);
-  cloned.shipping = convert(order.shipping);
-  cloned.tax = convert(order.tax);
-  cloned.items = order.items.map(i=>({ ...i, unit: convert(i.unit), subtotal: convert(i.subtotal) }));
-  return cloned;
-}

--- a/payments-config.json
+++ b/payments-config.json
@@ -1,6 +1,5 @@
 {
   "currencyDefault": "PKR",
-  "pkConversionRate": 278.00,
   "sandbox": true,
   "returnUrls": {
     "success": "/thank-you.html",


### PR DESCRIPTION
## Summary
- remove unused toPKR helper and related fx field usage
- drop pkConversionRate from payments config

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate:data`
- `npm run lint:static` (fails: broken link warnings)


------
https://chatgpt.com/codex/tasks/task_e_68adb1963da88320b1cf126ea203fadf