### PR TITLE
feat: standardize PKR currency formatting

### DIFF
--- a/404.html
+++ b/404.html
@@ -106,6 +106,7 @@
 <script src="/assets/js/bootstrap.bundle.min.js"></script>
 <script src="/assets/js/simpleCart.min.js"></script>
 <script src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/money.js"></script>
 <script src="/assets/js/storefront-runtime.js"></script>
 <script src="/assets/js/product-card.js"></script>
 <script src="/assets/js/tabs.js"></script>

--- a/about.html
+++ b/about.html
@@ -85,6 +85,7 @@
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/money.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>

--- a/assets/js/cart-page.js
+++ b/assets/js/cart-page.js
@@ -39,12 +39,8 @@ $(function () {
     return { subtotal, discount, tax, shipping: 0, grandTotal: grand };
   }
 
-  function formatCurrency(n) {
-    return new Intl.NumberFormat('en-PK', { style: 'currency', currency: getCurrency() }).format(n);
-  }
-
   function fmt(n) {
-    return formatCurrency(n);
+    return moneyPKR(n);
   }
 
   function renderItems() {
@@ -74,7 +70,7 @@ $(function () {
       if (metaText) info.append(meta);
       itemCol.append(thumb, info);
 
-      const priceCol = $('<div class="price"></div>').text(formatCurrency(item.get('price')));
+      const priceCol = $('<div class="price"></div>').text(moneyPKR(item.get('price')));
 
       const qtyCol = $('<div class="qty"></div>');
       const minus = $('<button type="button">-</button>');
@@ -82,7 +78,7 @@ $(function () {
       const plus = $('<button type="button">+</button>');
       qtyCol.append(minus, qtyInput, plus);
 
-      const totalCol = $('<div class="line-total"></div>').text(formatCurrency(item.total()));
+      const totalCol = $('<div class="line-total"></div>').text(moneyPKR(item.total()));
 
       const removeCol = $('<div class="remove" title="Remove">×</div>');
 

--- a/assets/js/cart-ui.js
+++ b/assets/js/cart-ui.js
@@ -9,9 +9,7 @@
   };
 
   function fmt(n){
-    if (window.ProductCard && ProductCard.formatDisplayPrice) return ProductCard.formatDisplayPrice(n, 'PKR');
-    try { return Number(n||0).toLocaleString(undefined, { maximumFractionDigits: 0 }); }
-    catch(_) { return (Number(n)||0).toString(); }
+    return moneyPKR(n);
   }
 
   function ensureSummaryBlocks(){

--- a/assets/js/money.js
+++ b/assets/js/money.js
@@ -1,0 +1,12 @@
+export function moneyPKR(value) {
+  const n = Number(value || 0);
+  try {
+    return new Intl.NumberFormat('en-PK', { style: 'currency', currency: 'PKR', maximumFractionDigits: 0 }).format(n);
+  } catch {
+    return '₨ ' + n.toLocaleString('en-PK', { maximumFractionDigits: 0 });
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.moneyPKR = moneyPKR;
+}

--- a/assets/js/payments.js
+++ b/assets/js/payments.js
@@ -97,7 +97,7 @@ export const Payments = {
   bank: {
     needsServer:false,
     async start(order, cfg){
-      const body = `\nORDER REQUEST (Bank Transfer)\nOrder: ${order.id}\nAmount: ${fmt(order.amount, order.currency)}\nItems:\n${order.items.map(i=>`• ${i.name} × ${i.qty} = ${fmt(i.subtotal, order.currency)}`).join('\n')}\n---\nBank details:\n${cfg.account.title}\n${cfg.account.bank} – ${cfg.account.branch}\nIBAN: ${cfg.account.iban}\nAccount#: ${cfg.account.accountNo}\n\nReply with transfer receipt to complete your order.`;
+      const body = `\nORDER REQUEST (Bank Transfer)\nOrder: ${order.id}\nAmount: ${fmt(order.amount)}\nItems:\n${order.items.map(i=>`• ${i.name} × ${i.qty} = ${fmt(i.subtotal)}`).join('\n')}\n---\nBank details:\n${cfg.account.title}\n${cfg.account.bank} – ${cfg.account.branch}\nIBAN: ${cfg.account.iban}\nAccount#: ${cfg.account.accountNo}\n\nReply with transfer receipt to complete your order.`;
       const mailto = `mailto:${cfg.mailto}?subject=${encodeURIComponent('Bank Transfer - '+order.id)}&body=${encodeURIComponent(body)}`;
       return { mailto };
     }
@@ -105,7 +105,7 @@ export const Payments = {
   cod: {
     needsServer:false,
     async start(order, cfg){
-      const body = `\nCOD REQUEST\nOrder: ${order.id}\nAmount to collect on delivery: ${fmt(order.amount, order.currency)}\nBuyer: ${safeBuyer(order.buyer)}\nItems:\n${order.items.map(i=>`• ${i.name} × ${i.qty}`).join('\n')}\nAddress: ${order.buyer?.address || '—'}\nPhone: ${order.buyer?.phone || '—'}\n`;
+      const body = `\nCOD REQUEST\nOrder: ${order.id}\nAmount to collect on delivery: ${fmt(order.amount)}\nBuyer: ${safeBuyer(order.buyer)}\nItems:\n${order.items.map(i=>`• ${i.name} × ${i.qty}`).join('\n')}\nAddress: ${order.buyer?.address || '—'}\nPhone: ${order.buyer?.phone || '—'}\n`;
       const mailto = `mailto:${cfg.mailto}?subject=${encodeURIComponent('COD - '+order.id)}&body=${encodeURIComponent(body)}`;
       return { mailto };
     }
@@ -114,7 +114,7 @@ export const Payments = {
     needsServer:false,
     async start(order){
       const raw = (document.documentElement?.dataset?.whatsapp || window.__SHOP_WHATSAPP__ || '').replace(/\D/g,'');
-      const formatTotal = (n)=> 'PKR ' + Number(n || 0).toLocaleString('en-PK');
+      const formatTotal = (n)=> moneyPKR(n);
       const lines = [];
       lines.push('New COD Order');
       if(order.buyer){
@@ -144,8 +144,8 @@ export const Payments = {
   }
 };
 
-export function fmt(n, ccy){
-  return new Intl.NumberFormat('en-PK', {style:'currency', currency: ccy}).format(n);
+export function fmt(n){
+  return moneyPKR(n);
 }
 
 function safeBuyer(b){

--- a/assets/js/pdp-hydrate.js
+++ b/assets/js/pdp-hydrate.js
@@ -121,9 +121,8 @@
   }
 
   function renderPrice(p){
-    var fmt = (window.ProductCard && ProductCard.formatPrice) ? ProductCard.formatPrice : function(n,c){ try{return new Intl.NumberFormat(undefined,{style:'currency',currency:c||'PKR'}).format(n);}catch(_){return (c||'PKR')+' '+(n||0);} };
-    var priceNew = fmt(p.price.current, p.price.currency);
-    var priceOld = p.price.old ? fmt(p.price.old, p.price.currency) : '';
+    var priceNew = moneyPKR(p.price.current);
+    var priceOld = p.price.old ? moneyPKR(p.price.old) : '';
     var block = document.querySelector('.pdp__price');
     if(block){
       block.innerHTML = `<span class="price price--new">${priceNew}</span>${priceOld?` <span class="price price--old">${priceOld}</span>`:''}`;

--- a/assets/js/pdp.js
+++ b/assets/js/pdp.js
@@ -27,13 +27,13 @@
   if(ratingEl && window.ProductCard){ ratingEl.innerHTML = ProductCard.renderProductCard({ rating:{ value: product.rating?.value || product.rating || 0, count: product.rating?.count || product.reviews || 0 }, id:'__r', url:'#', title:'', image:'' }).match(/pc__rating-stars"[^>]*>(.*?)<\/span>/)?.[1] || ''; }
 
   // Price
-  const priceNew = window.ProductCard?.formatPrice ? ProductCard.formatPrice(product.price?.current ?? product.price, product.price?.currency || product.currency || 'PKR') : (product.price?.current ?? product.price);
+  const priceNew = moneyPKR(product.price?.current ?? product.price);
   const priceOld = product.price?.old ?? product.compareAt ?? null;
   const priceBlock = document.querySelector('.pdp__price');
   if(priceBlock){
     priceBlock.innerHTML = `
       <span class="price price--new">${priceNew}</span>
-      ${priceOld? `<span class="price price--old">${ProductCard ? ProductCard.formatPrice(priceOld, product.price?.currency || product.currency || 'PKR') : priceOld}</span>`:''}
+      ${priceOld? `<span class="price price--old">${moneyPKR(priceOld)}</span>`:''}
     `;
     const mobilePrice = document.getElementById('mobile-atc-price');
     if(mobilePrice) mobilePrice.textContent = priceNew;

--- a/assets/js/product-card.js
+++ b/assets/js/product-card.js
@@ -15,22 +15,8 @@
     return list.includes(idStr);
   }
 
-  function formatPrice(n, currency='PKR'){
-    try{
-      return new Intl.NumberFormat(undefined, { style:'currency', currency }).format(n);
-    }catch{
-      // fallback
-      return (currency + ' ' + (n||0).toLocaleString());
-    }
-  }
-
-  // Add helper for market-friendly display of prices
-  function formatDisplayPrice(n, currency='PKR'){
-    // For PKR, many local stores drop the currency code. Show thousands separators only.
-    if((currency||'').toUpperCase() === 'PKR'){
-      return Number(n||0).toLocaleString(undefined, { maximumFractionDigits: 0 });
-      }
-    return formatPrice(n, currency);
+  function formatPrice(n){
+    return moneyPKR(n);
   }
 
   function starsSVG(value){
@@ -77,8 +63,8 @@
 
     const wishPressed = inWishlist(item.id);
     const wishLabel = wishPressed ? 'Remove from wishlist' : 'Add to wishlist';
-    const priceNew = formatDisplayPrice(item.price.current, item.price.currency);
-    const priceOld = item.price.old ? formatDisplayPrice(item.price.old, item.price.currency) : '';
+    const priceNew = moneyPKR(item.price.current);
+    const priceOld = item.price.old ? moneyPKR(item.price.old) : '';
 
     const oosClass = outOfStock ? ' pc--oos is-oos' : '';
     const atcLabel = outOfStock ? 'Out of stock' : 'Add to Cart';

--- a/assets/js/storefront-runtime.js
+++ b/assets/js/storefront-runtime.js
@@ -39,11 +39,11 @@ const StorefrontRuntime = (() => {
     return arr.slice(start, start + perPage);
   }
 
-  function formatPrice(value, currency) {
+  function formatPrice(value) {
     try {
-      return new Intl.NumberFormat('en-PK', { style: 'currency', currency: currency || 'PKR' }).format(value);
+      return moneyPKR(value);
     } catch (e) {
-      return value + ' ' + (currency || '');
+      return value + ' PKR';
     }
   }
 

--- a/c/index.html
+++ b/c/index.html
@@ -84,6 +84,7 @@
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/money.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>

--- a/cart.html
+++ b/cart.html
@@ -83,6 +83,7 @@
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/money.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>

--- a/categories/index.html
+++ b/categories/index.html
@@ -77,6 +77,7 @@
   <script src="/assets/js/jquery-2.2.4.min.js"></script>
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/money.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/tabs.js"></script>
   <script src="/assets/js/categories-page.js"></script>

--- a/contact.html
+++ b/contact.html
@@ -96,6 +96,7 @@
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/money.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>

--- a/cookie.html
+++ b/cookie.html
@@ -87,6 +87,7 @@
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/money.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>

--- a/docs/how-to-choose-serum.html
+++ b/docs/how-to-choose-serum.html
@@ -74,6 +74,7 @@
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/money.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>

--- a/faq.html
+++ b/faq.html
@@ -86,6 +86,7 @@
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/money.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>

--- a/index-old.html
+++ b/index-old.html
@@ -171,6 +171,7 @@
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/money.js"></script>
   <script type="module" src="/assets/js/analytics/index.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/product-card.js"></script>

--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/money.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>

--- a/p/index.html
+++ b/p/index.html
@@ -117,6 +117,7 @@
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/money.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>

--- a/privacy.html
+++ b/privacy.html
@@ -81,6 +81,7 @@
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/money.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>

--- a/returns.html
+++ b/returns.html
@@ -82,6 +82,7 @@
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/money.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>

--- a/sandbox/cards.html
+++ b/sandbox/cards.html
@@ -15,6 +15,7 @@
   <div class="container py-4">
     <div class="product-grid" id="demo-grid"></div>
   </div>
+  <script type="module" src="/assets/js/money.js"></script>
   <script src="/assets/js/product-card.js"></script>
   <script>
     const SAMPLE = [

--- a/search/index.html
+++ b/search/index.html
@@ -100,6 +100,7 @@
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/money.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>

--- a/shipping.html
+++ b/shipping.html
@@ -82,6 +82,7 @@
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/money.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>

--- a/terms.html
+++ b/terms.html
@@ -81,6 +81,7 @@
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/money.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>

--- a/thank-you.html
+++ b/thank-you.html
@@ -81,6 +81,7 @@
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/money.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>
@@ -88,7 +89,6 @@
     const data = localStorage.getItem('4d-last-order');
     const receipt = document.getElementById('order-receipt');
     const url = new URL(window.location);
-    const moneyPKR = (n) => 'PKR ' + Number(n || 0).toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 });
     if(data){
       const order = JSON.parse(data);
       const pm = url.searchParams.get('pm');

--- a/track-order.html
+++ b/track-order.html
@@ -81,6 +81,7 @@
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script src="/assets/js/simpleCart.min.js"></script>
   <script src="/assets/js/config.js"></script>
+  <script type="module" src="/assets/js/money.js"></script>
   <script src="/assets/js/storefront-runtime.js"></script>
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>


### PR DESCRIPTION
## Summary
- add reusable `moneyPKR` formatter and expose globally
- switch cart, product card and PDP pricing to `moneyPKR`
- load shared money formatter on pages that display prices

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:static` (fails: broken links)


------
https://chatgpt.com/codex/tasks/task_e_68adb52c689c8320ad4b1191d7468d1b