### PR TITLE
feat: add OG Aqua Jelly Highlighter Stick

### DIFF
--- a/assets/data/products.json
+++ b/assets/data/products.json
@@ -497,5 +497,29 @@
     "descriptionHTML": "<p>2-in-1 pure glow lip mask &amp; scrub providing 24-hour hydration, gently exfoliating and nourishing lips for a soft feel.</p>",
     "inStock": true,
     "sku": "SKN007"
+  },
+  {
+    "id": "HGL001",
+    "name": "OG Aqua Jelly Highlighter Stick",
+    "slug": "og-aqua-jelly-highlighter-stick",
+    "images": [
+      "/assets/img/products/IMG-20250820-WA0215.jpg",
+      "/assets/img/products/IMG-20250820-WA0216.jpg"
+    ],
+    "price": 1299,
+    "currency": "PKR",
+    "categories": [
+      "makeup",
+      "highlighter"
+    ],
+    "brand": "O.G",
+    "tags": [
+      "jelly",
+      "highlighter"
+    ],
+    "shortDescription": "Bouncy water-based gel stick delivers long-lasting, highly pigmented shine for a natural wet-look finish.",
+    "descriptionHTML": "<p>OG jelly highlighter stick is a bouncy, water-based gel stick that delivers a long-lasting, highly pigmented shine for a natural, wet-look finish.</p>",
+    "inStock": true,
+    "sku": "HGL001"
   }
 ]

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -42,4 +42,5 @@
   <url><loc>https://4dcosmetics.com/p/elfinz-lift-firm-booty-mask</loc></url>
   <url><loc>https://4dcosmetics.com/p/elfinz-neck-decollete-firming-cream</loc></url>
   <url><loc>https://4dcosmetics.com/p/og-lip-scrub-mask</loc></url>
+  <url><loc>https://4dcosmetics.com/p/og-aqua-jelly-highlighter-stick</loc></url>
 </urlset>


### PR DESCRIPTION
## Summary
- add OG Aqua Jelly Highlighter Stick product
- include highlighter in sitemap

## Testing
- `npm run validate:data`
- `npm run lint:static`
- `npm run test:sitemap`
- `npm run test:meta` *(fails: libatk-1.0.so.0 missing)*
- `npm run test:spa` *(fails: libatk-1.0.so.0 missing)*
- `npm run test:lighthouse` *(fails: CHROME_PATH not set)*
- `npm run test:features` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68adf8652bec8320b2670dfcb5bb9273