### PR TITLE
feat: add home search autocomplete

### DIFF
--- a/assets/css/bonanza-overrides.css
+++ b/assets/css/bonanza-overrides.css
@@ -20,7 +20,7 @@ small{ color:var(--muted); }
 .bnz-tab.is-active{ background:#111; color:#fff; }
 
 /* Search bar */
-.bnz-search{ display:flex; align-items:center; border:1px solid var(--border); border-radius:999px; padding:6px 10px; background:#fff; }
+.bnz-search{ display:flex; align-items:center; border:1px solid var(--border); border-radius:999px; padding:6px 10px; background:#fff; position:relative; }
 .bnz-search input[type="search"]{ border:0; outline:0; min-width:220px; height:30px; padding-left:8px; }
 .bnz-search button{ border:0; background:transparent; cursor:pointer; padding:0 6px; }
 

--- a/assets/js/search-autocomplete.js
+++ b/assets/js/search-autocomplete.js
@@ -1,6 +1,16 @@
 const CACHE_TTL = 120000; // 2 minutes
 const RECENT_KEY = 'search:recent';
 
+async function ensureSearchEngine() {
+  if (window.SearchEngine) return;
+  await new Promise(res => {
+    const s = document.createElement('script');
+    s.src = '/assets/js/search.js';
+    s.onload = res;
+    document.head.appendChild(s);
+  });
+}
+
 function analyticsEvent(type, data = {}) {
   try {
     if (window.gtag) {
@@ -258,7 +268,9 @@ function renderResults(data, q) {
 }
 
 function init() {
-  input = document.querySelector('[data-component="site-search-input"]') || document.querySelector('.search-form input[type="search"]');
+  input = document.querySelector('[data-component="site-search-input"]') ||
+          document.querySelector('.search-form input[type="search"]') ||
+          document.querySelector('.bnz-search input[type="search"]');
   if (!input) return;
   input.setAttribute('data-component', 'site-search-input');
   input.setAttribute('role', 'combobox');

--- a/assets/js/tabs.js
+++ b/assets/js/tabs.js
@@ -85,7 +85,7 @@
     `).join('');
   }
 
-  document.addEventListener('DOMContentLoaded', async function(){
+document.addEventListener('DOMContentLoaded', async function(){
     try{
       const raw = await loadCategories();
       if (raw && raw.length){
@@ -105,3 +105,11 @@
     }
   });
 })();
+
+// Load search autocomplete module on every page
+document.addEventListener('DOMContentLoaded', function(){
+  const s = document.createElement('script');
+  s.type = 'module';
+  s.src = '/assets/js/search-autocomplete.js';
+  document.head.appendChild(s);
+});


### PR DESCRIPTION
## Summary
- load search autocomplete module on every page for instant product suggestions
- support existing Bonanza search bar markup and ensure search engine is available
- anchor search bar styling so suggestion dropdown displays correctly

## Testing
- `npm run lint:static`
- `npm run test:meta` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npm run test:sitemap`


------
https://chatgpt.com/codex/tasks/task_e_68adfb1972588320aca8ba7fc470c3f3