### PR TITLE
Fix empty category pages listing all products

### DIFF
--- a/assets/js/collection.js
+++ b/assets/js/collection.js
@@ -121,7 +121,7 @@
 
   function renderGrid(items){
     if (!items.length){
-      grid.innerHTML = '<p class="text-center text-muted my-4">No products found in this category.</p>';
+      grid.innerHTML = '<p class="text-center text-muted my-4">No products available yet.</p>';
       return;
     }
     // use ProductCard renderer if present, else fallback to ui-cards buildProductCard
@@ -166,8 +166,6 @@
       all = all.map(function(x){ return x.product || x.node || x; });
       // Filter to category
       var filtered = all.filter(function(p){ return belongsToCategory(p, CAT_SLUG); });
-      // If filtering produced nothing but we had products, fallback to all
-      if (!filtered.length && all.length) filtered = all;
       // Sort
       filtered = applySort(filtered, getSort());
       // Limit initial render to something reasonable
@@ -177,6 +175,7 @@
       // Simple "Load more" if legacy button exists
       var btn = document.getElementById('load-more');
       if (btn){
+        if (filtered.length <= initial.length) btn.disabled = true;
         var cursor = 24;
         btn.addEventListener('click', function(){
           var next = filtered.slice(cursor, cursor+24);


### PR DESCRIPTION
## Summary
- prevent empty categories from falling back to all products
- show "No products available yet." when category has no items and disable load-more

## Testing
- `npm run lint:static`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68adfe3c7e348320b5db3f3c0c7e08a2