### PR TITLE
fix: prevent listing all products for empty categories

### DIFF
--- a/assets/js/collection.js
+++ b/assets/js/collection.js
@@ -121,7 +121,7 @@
 
   function renderGrid(items){
     if (!items.length){
-      grid.innerHTML = '<p class="text-center text-muted my-4">No products found in this category.</p>';
+      grid.innerHTML = '<p class="text-center text-muted my-4">No products available yet.</p>';
       return;
     }
     // use ProductCard renderer if present, else fallback to ui-cards buildProductCard
@@ -166,8 +166,11 @@
       all = all.map(function(x){ return x.product || x.node || x; });
       // Filter to category
       var filtered = all.filter(function(p){ return belongsToCategory(p, CAT_SLUG); });
-      // If filtering produced nothing but we had products, fallback to all
-      if (!filtered.length && all.length) filtered = all;
+      // If filtering produced nothing, render empty state
+      if (!filtered.length){
+        renderGrid([]);
+        return;
+      }
       // Sort
       filtered = applySort(filtered, getSort());
       // Limit initial render to something reasonable


### PR DESCRIPTION
## Summary
- show empty category message instead of fallback to all products
- display "No products available yet" text when a category has no products

## Testing
- `npm run lint:static`
- `npm run test:sitemap`
- `npm run test:features` *(fails: libXdamage.so.1 missing)*


------
https://chatgpt.com/codex/tasks/task_e_68ae02b27b30832083633a5e13f382a7