### PR TITLE
Show product suggestions without text hints

### DIFF
--- a/assets/js/header-nav.js
+++ b/assets/js/header-nav.js
@@ -1,15 +1,3 @@
-async function ensureSearchEngine() {
-  if (window.SearchEngine) return;
-  await new Promise(res => {
-    const s = document.createElement('script');
-    s.src = '/assets/js/search.js';
-    s.onload = res;
-    document.head.appendChild(s);
-  });
-}
-
-function debounce(fn, delay){ let t; return (...args)=>{ clearTimeout(t); t=setTimeout(()=>fn(...args),delay); }; }
-
 document.documentElement.classList.add('js');
 
 function navEvent(type, data = {}) {
@@ -136,11 +124,13 @@ function initMobileNav() {
 
 document.addEventListener('DOMContentLoaded', async () => {
   try {
-    const s = document.createElement('script');
-    s.type = 'module';
-    s.src = '/assets/js/search-autocomplete.js';
-    document.head.appendChild(s);
-    await ensureSearchEngine();
+    document.querySelectorAll('input[type="search"]').forEach(i => {
+      i.setAttribute('autocomplete', 'off');
+      i.setAttribute('autocorrect', 'off');
+      i.setAttribute('autocapitalize', 'off');
+      i.setAttribute('spellcheck', 'false');
+      i.removeAttribute('name');
+    });
     const categories = await StorefrontRuntime.loadCategories();
     const topCats = categories.filter(c => !c.parent)
       .sort((a, b) => (a.sortOrder - b.sortOrder) || a.name.localeCompare(b.name));
@@ -206,14 +196,6 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const collapse = document.getElementById('navbarNav');
     if (collapse) {
-      const form = document.createElement('form');
-      form.className = 'd-flex ms-lg-3 position-relative';
-      form.setAttribute('role', 'search');
-      form.addEventListener('submit', e => {
-        e.preventDefault();
-        const q = input.value.trim();
-        if (q) window.location.href = `/search/?q=${encodeURIComponent(q)}`;
-      });
       const input = document.createElement('input');
       input.type = 'search';
       input.className = 'form-control';
@@ -221,59 +203,17 @@ document.addEventListener('DOMContentLoaded', async () => {
       input.id = 'header-search';
       input.autocomplete = 'off';
       input.setAttribute('aria-label', 'Search products');
-      input.setAttribute('aria-expanded', 'false');
-      form.appendChild(input);
-      const panel = document.createElement('div');
-      panel.id = 'search-autocomplete';
-      panel.className = 'list-group position-absolute top-100 start-0 w-100 d-none';
-      panel.setAttribute('role', 'listbox');
-      form.appendChild(panel);
-      collapse.appendChild(form);
 
-      let activeIndex = -1;
-      function hidePanel(){ panel.classList.add('d-none'); input.setAttribute('aria-expanded','false'); input.removeAttribute('aria-activedescendant'); activeIndex=-1; }
-      function setActive(){ Array.from(panel.children).forEach((el,i)=>{ if(i===activeIndex){ el.classList.add('active'); input.setAttribute('aria-activedescendant', el.id);} else el.classList.remove('active'); }); }
-      const update = debounce(async () => {
+      const form = document.createElement('form');
+      form.className = 'search-form d-flex ms-lg-3 position-relative';
+      form.setAttribute('role', 'search');
+      form.addEventListener('submit', e => {
+        e.preventDefault();
         const q = input.value.trim();
-        if (!q){ hidePanel(); return; }
-        const results = await SearchEngine.search(q);
-        panel.innerHTML='';
-        activeIndex=-1;
-        if (results.length) {
-          results.slice(0,8).forEach((prod,i)=>{
-            const a=document.createElement('a');
-            a.href=`/p/${prod.slug}`;
-            a.className='list-group-item list-group-item-action d-flex align-items-center';
-            a.setAttribute('role','option');
-            a.id=`ac-item-${i}`;
-            const img=document.createElement('img'); img.src=prod.images[0]; img.alt=''; img.width=40; img.height=40; img.loading='lazy'; img.className='me-2'; a.appendChild(img);
-            const span=document.createElement('span'); span.textContent=prod.name; a.appendChild(span);
-            if(prod.brand){ const b=document.createElement('small'); b.className='text-muted ms-1'; b.textContent=prod.brand; a.appendChild(b); }
-            const price=document.createElement('span'); price.className='ms-auto'; price.textContent=StorefrontRuntime.formatPrice(prod.price, prod.currency); a.appendChild(price);
-            panel.appendChild(a);
-          });
-          const view=document.createElement('a'); view.href=`/search/?q=${encodeURIComponent(q)}`; view.className='list-group-item list-group-item-action'; view.textContent=`View all results for "${q}"`; panel.appendChild(view);
-        } else {
-          const div=document.createElement('div'); div.className='list-group-item'; div.textContent='No matches. Press Enter to search all results.'; panel.appendChild(div);
-        }
-        panel.classList.remove('d-none');
-        input.setAttribute('aria-expanded','true');
-      },150);
-
-      input.addEventListener('input', update);
-      input.addEventListener('focus', update);
-      input.addEventListener('keydown', e => {
-        if (e.key === 'ArrowDown' && !panel.classList.contains('d-none')) { e.preventDefault(); activeIndex=(activeIndex+1)%panel.children.length; setActive(); }
-        else if (e.key === 'ArrowUp' && !panel.classList.contains('d-none')) { e.preventDefault(); activeIndex=(activeIndex-1+panel.children.length)%panel.children.length; setActive(); }
-        else if (e.key === 'Enter') {
-          if (!panel.classList.contains('d-none') && activeIndex>=0) {
-            const el=panel.children[activeIndex]; const href=el.getAttribute('href'); if(href) window.location.href=href; else window.location.href=`/search/?q=${encodeURIComponent(input.value.trim())}`;
-          } else if (input.value.trim()) {
-            window.location.href=`/search/?q=${encodeURIComponent(input.value.trim())}`;
-          }
-        } else if (e.key === 'Escape') { hidePanel(); }
+        if (q) window.location.href = `/search/?q=${encodeURIComponent(q)}`;
       });
-      document.addEventListener('click', e => { if(!form.contains(e.target)) hidePanel(); });
+      form.appendChild(input);
+      collapse.appendChild(form);
     }
 
       const footerContainer = document.querySelector('footer .container');

--- a/assets/js/search-autocomplete.js
+++ b/assets/js/search-autocomplete.js
@@ -1,5 +1,4 @@
 const CACHE_TTL = 120000; // 2 minutes
-const RECENT_KEY = 'search:recent';
 
 async function ensureSearchEngine() {
   if (window.SearchEngine) return;
@@ -31,28 +30,6 @@ function debounce(fn, delay) {
   };
 }
 
-function getRecent() {
-  try {
-    const arr = JSON.parse(localStorage.getItem(RECENT_KEY) || '[]');
-    return Array.isArray(arr) ? arr : [];
-  } catch {
-    return [];
-  }
-}
-
-function saveRecent(q) {
-  const list = getRecent().filter(x => x !== q);
-  list.unshift(q);
-  if (list.length > 5) list.length = 5;
-  try {
-    localStorage.setItem(RECENT_KEY, JSON.stringify(list));
-  } catch {}
-}
-
-function clearRecent() {
-  try { localStorage.removeItem(RECENT_KEY); } catch {}
-}
-
 function buildProductItem(p, index) {
   const li = document.createElement('div');
   li.className = 'search-option product d-flex align-items-center';
@@ -69,23 +46,9 @@ function buildProductItem(p, index) {
   return li;
 }
 
-function buildCategoryItem(c, index) {
-  const li = document.createElement('div');
-  li.className = 'search-option category';
-  li.id = `search-option-${index}`;
-  li.setAttribute('role', 'option');
-  li.setAttribute('data-type', 'category');
-  li.setAttribute('data-url', c.url);
-  li.textContent = `Shop ${c.name} (${c.count})`;
-  return li;
-}
-
 async function searchAPI(q, limit = 6, signal) {
   await ensureSearchEngine();
-  const [productsRaw, categories] = await Promise.all([
-    SearchEngine.search(q),
-    StorefrontRuntime.loadCategories()
-  ]);
+  const productsRaw = await SearchEngine.search(q);
 
   const norm = q.trim().toLowerCase();
   const products = productsRaw.slice(0, limit).map(p => ({
@@ -99,44 +62,7 @@ async function searchAPI(q, limit = 6, signal) {
     badges: StorefrontRuntime.getProductBadges(p).map(b => b.label)
   }));
 
-  const tokens = norm.split(/\s+/).filter(Boolean);
-  const catMatches = categories.filter(c => {
-    const n = c.name.toLowerCase();
-    return tokens.some(t => n.includes(t));
-  }).slice(0, 3).map(c => ({
-    name: c.name,
-    url: `/c/${c.slug}/`,
-    count: StorefrontRuntime.listProductsForCategory(c.slug).length
-  }));
-
-  return { products, categories: catMatches, suggestions: [] };
-}
-
-function renderRecent(container) {
-  const rec = getRecent();
-  if (!rec.length) return false;
-  const wrap = document.createElement('div');
-  wrap.className = 'recent-searches mb-2';
-  rec.forEach(q => {
-    const b = document.createElement('button');
-    b.type = 'button';
-    b.className = 'btn btn-sm btn-outline-secondary me-1 mb-1';
-    b.textContent = q;
-    b.addEventListener('click', () => {
-      input.value = q;
-      input.dispatchEvent(new Event('input'));
-      input.focus();
-    });
-    wrap.appendChild(b);
-  });
-  const clr = document.createElement('button');
-  clr.type = 'button';
-  clr.className = 'btn btn-sm btn-link';
-  clr.textContent = 'Clear';
-  clr.addEventListener('click', () => { clearRecent(); close(); });
-  wrap.appendChild(clr);
-  container.appendChild(wrap);
-  return true;
+  return { products };
 }
 
 function renderEmpty(container, q) {
@@ -189,7 +115,6 @@ function selectCurrent() {
     id: el.getAttribute('data-id') || '',
     position: activeIndex + 1
   });
-  saveRecent(input.value.trim());
   window.location.href = url;
 }
 
@@ -197,8 +122,8 @@ async function handleInput() {
   const q = input.value.trim();
   if (!q) {
     results.innerHTML = '';
-    if (!renderRecent(results)) { close(); if (liveRegion) liveRegion.textContent = ''; }
-    else { open(); if (liveRegion) liveRegion.textContent = ''; }
+    close();
+    if (liveRegion) liveRegion.textContent = '';
     return;
   }
   if (q.length < 2) { close(); return; }
@@ -219,50 +144,28 @@ async function handleInput() {
   }
   renderResults(data, q);
   analyticsEvent('search_suggestion_impression', {
-    products: data.products.length,
-    categories: data.categories.length
+    products: data.products.length
   });
 }
 
 function renderResults(data, q) {
   results.innerHTML = '';
   items = [];
-  if (!data.products.length && !data.categories.length) {
+  if (!data.products.length) {
     renderEmpty(results, q);
     open();
     return;
   }
-  if (liveRegion) liveRegion.textContent = `${data.products.length + data.categories.length} results`;
+  if (liveRegion) liveRegion.textContent = `${data.products.length} results`;
   const frag = document.createDocumentFragment();
-  if (data.products.length) {
-    const header = document.createElement('div');
-    header.className = 'px-2 pt-2 text-muted small';
-    header.textContent = 'Products';
-    frag.appendChild(header);
-    data.products.forEach((p, i) => {
-      const el = buildProductItem(p, items.length);
-      frag.appendChild(el); items.push(el);
-    });
-  }
-  if (data.categories.length) {
-    const header = document.createElement('div');
-    header.className = 'px-2 pt-2 text-muted small';
-    header.textContent = 'Categories';
-    frag.appendChild(header);
-    data.categories.forEach(c => {
-      const el = buildCategoryItem(c, items.length);
-      frag.appendChild(el); items.push(el);
-    });
-  }
-  const footer = document.createElement('div');
-  footer.id = `search-option-${items.length}`;
-  footer.setAttribute('role', 'option');
-  footer.setAttribute('data-type', 'see_all');
-  footer.setAttribute('data-url', `/search/?q=${encodeURIComponent(q)}`);
-  footer.setAttribute('data-action', 'search-view-all');
-  footer.className = 'search-option see-all';
-  footer.textContent = `See all results for "${q}"`;
-  frag.appendChild(footer); items.push(footer);
+  const header = document.createElement('div');
+  header.className = 'px-2 pt-2 text-muted small';
+  header.textContent = 'Products';
+  frag.appendChild(header);
+  data.products.forEach((p, i) => {
+    const el = buildProductItem(p, items.length);
+    frag.appendChild(el); items.push(el);
+  });
   results.appendChild(frag);
   open();
 }
@@ -272,6 +175,7 @@ function init() {
           document.querySelector('.search-form input[type="search"]') ||
           document.querySelector('.bnz-search input[type="search"]');
   if (!input) return;
+  if (!input.id) input.id = 'header-search';
   input.setAttribute('data-component', 'site-search-input');
   input.setAttribute('role', 'combobox');
   input.setAttribute('aria-autocomplete', 'list');
@@ -294,12 +198,11 @@ function init() {
     document.body.appendChild(liveRegion);
   }
 
-  input.addEventListener('focus', () => { analyticsEvent('search_focus'); handleInput(); });
+  input.addEventListener('focus', () => { analyticsEvent('search_focus'); });
   input.addEventListener('input', debounce(handleInput, 200));
   input.form && input.form.addEventListener('submit', () => {
     const q = input.value.trim();
     analyticsEvent('search_submit', { query: q });
-    saveRecent(q);
   });
 
   input.addEventListener('keydown', e => {

--- a/scripts/tests/features.js
+++ b/scripts/tests/features.js
@@ -59,20 +59,21 @@ function startServer(){
   }));
   if (!/No products found/i.test(data.empty)) {failed=true; report.push('Search empty state missing');}
 
-  // autocomplete smoke
+  // autocomplete product suggestions
   await page.goto(`http://localhost:${port}/`,{waitUntil:'networkidle0'});
   await page.waitForSelector('#header-search');
-  await page.waitForTimeout(500);
   await page.focus('#header-search');
+  let panel = await page.$('#site-search-results:not(.d-none)');
+  if (panel) {failed=true; report.push('Suggestions visible before typing');}
   const prefix = first.name.slice(0,3);
   await page.type('#header-search', prefix);
-  await page.waitForSelector('#search-autocomplete:not(.d-none)',{timeout:10000});
-  const sugg = await page.$$eval('#search-autocomplete a', els => els.length);
-  if (sugg < 1) {failed=true; report.push('Autocomplete suggestions missing');}
+  await page.waitForSelector('#site-search-results:not(.d-none)',{timeout:10000});
+  const sugg = await page.$$eval('#site-search-results .search-option.product', els => els.length);
+  if (sugg < 1) {failed=true; report.push('Product suggestions missing');}
   await page.keyboard.press('ArrowDown');
   await page.keyboard.press('Enter');
   await page.waitForNavigation({waitUntil:'networkidle0'});
-  const title = await page.$eval('#product-title', el=>el.textContent);
+  const title = await page.$eval('.pdp__title', el=>el.textContent);
   if (!title.includes(first.name)) {failed=true; report.push('Autocomplete navigation failed');}
 
   // recently viewed


### PR DESCRIPTION
## Summary
- strip category links and "See all results" from autocomplete dropdown
- limit search API to product matches so only product cards appear

## Testing
- `npm run lint:static`
- `npm run test:features` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68adfd8aa96c8320b4fbc47850f5d00a