### PR TITLE
fix: remove module syntax from config script

### DIFF
--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -1,5 +1,8 @@
-export const SHOP_CURRENCY = 'PKR';
-export const SHOP_CURRENCY_SYMBOL = '₨';
+// Currency configuration for the shop.
+// Define constants without ES module syntax so the script can run
+// in browsers that load it as a classic script tag.
+const SHOP_CURRENCY = 'PKR';
+const SHOP_CURRENCY_SYMBOL = '₨';
 
 // Register Pakistani Rupee currency before configuring simpleCart
 simpleCart.currency({


### PR DESCRIPTION
## Summary
- prevent `config.js` from using ES module exports, allowing browsers to parse it as a classic script
- document currency constants within `config.js`

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:static` (fails: broken links / account.html, /wishlist.html, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68ae128a1ab083209893a3f268c817d5