### PR TITLE
Fix continue shopping link to home

### DIFF
--- a/thank-you.html
+++ b/thank-you.html
@@ -47,7 +47,7 @@
       <h1>Thank you</h1>
       <p>Your order has been received.</p>
       <div id="order-receipt"></div>
-      <a href="categories/" class="btn btn-primary mt-3">Continue shopping</a>
+      <a href="/" class="btn btn-primary mt-3">Continue shopping</a>
     </div>
   </main>
 


### PR DESCRIPTION
## Summary
- direct the thank-you page's Continue shopping button to the home page

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint:static` *(fails: link issues)*
- `npm run validate:data` *(fails: missing categories)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1653396083209c8ceee2aab9aa38