### PR TITLE
Hide load more button when no products

### DIFF
--- a/assets/js/collection.js
+++ b/assets/js/collection.js
@@ -122,6 +122,8 @@
   function renderGrid(items){
     if (!items.length){
       grid.innerHTML = '<p class="text-center text-muted my-4">No products available yet.</p>';
+      var lmWrap = document.querySelector('.bnz-loadmore');
+      if (lmWrap) lmWrap.style.display = 'none';
       return;
     }
     // use ProductCard renderer if present, else fallback to ui-cards buildProductCard


### PR DESCRIPTION
## Summary
- hide Load More button when category has no products

## Testing
- `npm run lint:static` (reported link issues)
- `npm run validate:data` (reported missing category references)


------
https://chatgpt.com/codex/tasks/task_e_68ae16c1cb748320ac3bc3f326d99aef