### PR TITLE
Ensure load more button matches product count

### DIFF
--- a/assets/js/collection.js
+++ b/assets/js/collection.js
@@ -182,7 +182,9 @@
       // Simple "Load more" if legacy button exists
       var btn = document.getElementById('load-more');
       if (btn){
-        var cursor = 24;
+        var cursor = initial.length;
+        btn.disabled = cursor >= filtered.length;
+        if (btn.disabled && btn.parentElement) btn.parentElement.style.display = 'none';
         btn.addEventListener('click', function(){
           var next = filtered.slice(cursor, cursor+24);
           cursor += 24;
@@ -197,7 +199,10 @@
               });
             }
           }
-          if (cursor >= filtered.length) btn.disabled = true;
+          if (cursor >= filtered.length){
+            btn.disabled = true;
+            if (btn.parentElement) btn.parentElement.style.display = 'none';
+          }
         });
       }
     }catch(e){

--- a/assets/js/home-feed.js
+++ b/assets/js/home-feed.js
@@ -73,11 +73,15 @@
     var page = 0, size = 24;
     var all = await loadAllProducts();
     var btn = document.getElementById('load-more');
+    var wrap = btn ? btn.parentElement : null;
     function draw(){
       var slice = all.slice(0, (page+1)*size);
       renderGrid(slice);
       updateProgress(slice.length, all.length);
-      if (slice.length >= all.length && btn) btn.disabled = true;
+      if (btn){
+        btn.disabled = slice.length >= all.length;
+        if (wrap) wrap.style.display = btn.disabled ? 'none' : '';
+      }
     }
     if (btn){ btn.addEventListener('click', function(){ page++; draw(); }); }
     draw();


### PR DESCRIPTION
## Summary
- Correctly initialize and update load-more button on category pages
- Hide or disable load-more button on the homepage when all products are shown

## Testing
- ⚠️ `npm test` (no test specified)
- ⚠️ `npm run lint:static` (link issues reported)


------
https://chatgpt.com/codex/tasks/task_e_68ae17cfac1883209b2f966a1997622a