### PR TITLE
Show viewed products progress on all listing pages

### DIFF
--- a/assets/js/collection.js
+++ b/assets/js/collection.js
@@ -178,6 +178,9 @@
       // Limit initial render to something reasonable
       var initial = filtered.slice(0, 24);
       renderGrid(initial);
+      if (window.__updateCollectionProgress){
+        window.__updateCollectionProgress(initial.length, filtered.length);
+      }
 
       // Simple "Load more" if legacy button exists
       var btn = document.getElementById('load-more');
@@ -198,6 +201,9 @@
                 if (el) grid.appendChild(el);
               });
             }
+          }
+          if (window.__updateCollectionProgress){
+            window.__updateCollectionProgress(Math.min(cursor, filtered.length), filtered.length);
           }
           if (cursor >= filtered.length){
             btn.disabled = true;

--- a/assets/js/search-page.js
+++ b/assets/js/search-page.js
@@ -12,7 +12,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   const sortSel = document.getElementById('sort');
   const perPage = 12;
   const loadMoreBtn = document.getElementById('load-more');
-  const loadMoreContainer = document.getElementById('load-more-container');
+  // load-more container may not have an explicit id in markup
+  const loadMoreContainer = document.getElementById('load-more-container') || loadMoreBtn.parentElement;
   let sort = params.get('sort') || 'featured';
   let page = parseInt(params.get('page') || '1',10);
   let currentItems = [];
@@ -75,6 +76,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     loadedPage++;
     Analytics.viewItemList(rendered, 'Search results');
     updateLD();
+    if (window.__updateSearchProgress){
+      const viewed = Math.min(loadedPage * perPage, currentItems.length);
+      window.__updateSearchProgress(viewed, currentItems.length);
+    }
   }
 
   function updateLoadMore(){


### PR DESCRIPTION
## Summary
- ensure search page progress bar updates as products load
- update category listing to show viewed/total product count

## Testing
- `npm run lint:static`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae19c96b70832084dd7b645c369b1e