### PR TITLE
Center tab navigation across screen sizes

### DIFF
--- a/assets/css/bonanza-overrides.css
+++ b/assets/css/bonanza-overrides.css
@@ -16,6 +16,10 @@ small{ color:var(--muted); }
 .bnz-tabs{
   border-top:1px solid var(--border);
   background:#fff;
+}
+
+/* Center tab rail on all screen sizes */
+.bnz-tabs .container-narrow{
   justify-content:center;
 }
 .bnz-tab{ display:inline-flex; align-items:center; padding:8px 14px; border-radius:999px; background:#f0f0f0; color:#111; text-decoration:none; font-size:14px; }


### PR DESCRIPTION
## Summary
- center tab rail consistently on all screens so navigation remains visible and centered

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static` *(fails: broken links)*
- `npm run test:meta` *(fails: missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1efa42e08320a3d476d90bf93b0b