### PR TITLE
Fix cart layout overflow on mobile

### DIFF
--- a/assets/css/cart.css
+++ b/assets/css/cart.css
@@ -85,7 +85,8 @@ main.container{width:100%;max-width:1120px;margin:0 auto;padding:0 var(--space-4
   .qty input{width:32px}
 }
 
-.cart{ display:grid; gap:var(--space-6); }
+.cart{ display:grid; gap:var(--space-6); grid-template-columns:1fr; }
+.cart > *{ width:100%; }
 @media(min-width:992px){ .cart{ grid-template-columns: 2fr 1fr; } }
 
 .cart-line{ display:grid; grid-template-columns: 72px 1fr auto; gap:12px; padding:12px; border:1px solid var(--border);


### PR DESCRIPTION
## Summary
- stretch cart sections to span full width on small screens to prevent left alignment

## Testing
- `npm run lint:static`
- `npm run test:features`


------
https://chatgpt.com/codex/tasks/task_e_68ae15ff0aec8320916a4d450e02a4e9