### PR TITLE
Fix missing product page assets

### DIFF
--- a/404.html
+++ b/404.html
@@ -42,9 +42,9 @@
     })();
   </script>
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
 <div class="annc" role="region" aria-label="Site announcement">
@@ -114,6 +114,6 @@
 <script src="/assets/js/product-card.js"></script>
 <script src="/assets/js/tabs.js"></script>
   <script src="/assets/js/whatsapp-fab.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -13,9 +13,9 @@
   <link rel="stylesheet" href="/assets/css/product-card.css">
   <link rel="stylesheet" href="/assets/css/bonanza-layout.css">
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
 
@@ -93,6 +93,6 @@
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>
   <script src="/assets/js/whatsapp-fab.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>

--- a/c/index.html
+++ b/c/index.html
@@ -13,9 +13,9 @@
   <link rel="stylesheet" href="/assets/css/product-card.css">
   <link rel="stylesheet" href="/assets/css/bonanza-layout.css">
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
   
@@ -104,6 +104,6 @@
   };
   </script>
   <script src="/assets/js/whatsapp-fab.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>

--- a/cart.cz.html
+++ b/cart.cz.html
@@ -11,9 +11,9 @@
   <link rel="stylesheet" href="/assets/css/bonanza-layout.css">
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
   <link rel="stylesheet" href="/assets/css/cart.cz.css">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
 
@@ -133,13 +133,13 @@
   <script type="module" src="/assets/js/checkout.js"></script>
   <script src="/assets/js/cart-ui.js"></script>
   <script src="/assets/js/whatsapp-fab.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>
 
   <script src="/assets/js/jquery-2.2.4.min.js"></script>
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script src="/assets/js/cart.cz.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>

--- a/cart.html
+++ b/cart.html
@@ -13,9 +13,9 @@
   <link rel="stylesheet" href="/assets/css/bonanza-layout.css">
   <link rel="stylesheet" href="/assets/css/cart.css">
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
   
@@ -93,6 +93,6 @@
   <script type="module" src="/assets/js/checkout.js"></script>
   <script src="/assets/js/cart-ui.js"></script>
   <script src="/assets/js/whatsapp-fab.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>

--- a/categories/index.html
+++ b/categories/index.html
@@ -12,9 +12,9 @@
   <link rel="stylesheet" href="/assets/css/theme.css">
   <link rel="stylesheet" href="/assets/css/bonanza-layout.css">
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
   
@@ -86,6 +86,6 @@
   <script src="/assets/js/categories-page.js"></script>
   <script src="/assets/js/whatsapp-fab.js"></script>
   <script src="/assets/js/home-bonanza.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -13,9 +13,9 @@
   <link rel="stylesheet" href="/assets/css/product-card.css">
   <link rel="stylesheet" href="/assets/css/bonanza-layout.css">
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
 
@@ -104,6 +104,6 @@
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>
   <script src="/assets/js/whatsapp-fab.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>

--- a/cookie.html
+++ b/cookie.html
@@ -13,9 +13,9 @@
   <link rel="stylesheet" href="/assets/css/product-card.css">
   <link rel="stylesheet" href="/assets/css/bonanza-layout.css">
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
 
@@ -95,6 +95,6 @@
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>
   <script src="/assets/js/whatsapp-fab.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>

--- a/docs/how-to-choose-serum.html
+++ b/docs/how-to-choose-serum.html
@@ -14,9 +14,9 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
 
@@ -85,6 +85,6 @@
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>
   <script src="/assets/js/whatsapp-fab.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -13,9 +13,9 @@
   <link rel="stylesheet" href="/assets/css/product-card.css">
   <link rel="stylesheet" href="/assets/css/bonanza-layout.css">
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
 
@@ -94,6 +94,6 @@
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>
   <script src="/assets/js/whatsapp-fab.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>

--- a/index-old.html
+++ b/index-old.html
@@ -14,9 +14,9 @@
   <link rel="stylesheet" href="/assets/css/product-card.css">
   <link rel="stylesheet" href="/assets/css/bonanza-layout.css">
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
   <a class="skip-link" href="#main">Skip to main content</a>
@@ -183,6 +183,6 @@
   <script type="module" src="/assets/js/home-page.js"></script>
   <script src="/assets/js/diagnostics-overlay.js" defer></script>
     <script src="/assets/js/whatsapp-fab.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
   </html>

--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@
   <link rel="stylesheet" href="/assets/css/product-card.css">
   <link rel="stylesheet" href="/assets/css/bonanza-layout.css">
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
   
@@ -164,6 +164,6 @@
   <script src="/assets/js/home-feed.js"></script>
   <script src="/assets/js/whatsapp-fab.js"></script>
   <script src="/assets/js/home-bonanza.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>

--- a/p/index.html
+++ b/p/index.html
@@ -14,9 +14,9 @@
   <link rel="stylesheet" href="/assets/css/bonanza-layout.css">
   <link rel="stylesheet" href="/assets/css/pdp.css">
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
   
@@ -127,6 +127,6 @@
   <script src="/assets/js/pdp.js"></script>
 <script src="/assets/js/pdp-hydrate.js"></script>
   <script src="/assets/js/whatsapp-fab.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -13,9 +13,9 @@
   <link rel="stylesheet" href="/assets/css/product-card.css">
   <link rel="stylesheet" href="/assets/css/bonanza-layout.css">
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
 
@@ -89,6 +89,6 @@
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>
   <script src="/assets/js/whatsapp-fab.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>

--- a/returns.html
+++ b/returns.html
@@ -13,9 +13,9 @@
   <link rel="stylesheet" href="/assets/css/product-card.css">
   <link rel="stylesheet" href="/assets/css/bonanza-layout.css">
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
 
@@ -91,6 +91,6 @@
   <script src="/assets/js/tabs.js"></script>
 
   <script src="/assets/js/whatsapp-fab.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>

--- a/sandbox/cards.html
+++ b/sandbox/cards.html
@@ -13,9 +13,9 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body>
   <div class="container py-4">
@@ -40,6 +40,6 @@
     });
   </script>
   <script src="/assets/js/whatsapp-fab.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>

--- a/search/index.html
+++ b/search/index.html
@@ -14,9 +14,9 @@
   <link rel="stylesheet" href="/assets/css/product-card.css">
   <link rel="stylesheet" href="/assets/css/bonanza-layout.css">
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
   
@@ -122,6 +122,6 @@
   };
   </script>
   <script src="/assets/js/whatsapp-fab.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>

--- a/shipping.html
+++ b/shipping.html
@@ -13,9 +13,9 @@
   <link rel="stylesheet" href="/assets/css/product-card.css">
   <link rel="stylesheet" href="/assets/css/bonanza-layout.css">
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
 
@@ -90,6 +90,6 @@
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>
   <script src="/assets/js/whatsapp-fab.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -13,9 +13,9 @@
   <link rel="stylesheet" href="/assets/css/product-card.css">
   <link rel="stylesheet" href="/assets/css/bonanza-layout.css">
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
 
@@ -89,6 +89,6 @@
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>
   <script src="/assets/js/whatsapp-fab.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>

--- a/thank-you.html
+++ b/thank-you.html
@@ -16,9 +16,9 @@
   <link rel="stylesheet" href="/assets/css/checkout.css">
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
   <link rel="stylesheet" href="/assets/css/thank-you.css">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
 
@@ -113,6 +113,6 @@
     }
   </script>
   <script src="/assets/js/whatsapp-fab.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>

--- a/track-order.html
+++ b/track-order.html
@@ -13,9 +13,9 @@
   <link rel="stylesheet" href="/assets/css/product-card.css">
   <link rel="stylesheet" href="/assets/css/bonanza-layout.css">
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
-<link rel="stylesheet" href="./css/base.css?v=1">
-<link rel="stylesheet" href="./css/components.css?v=1">
-<link rel="stylesheet" href="./css/utilities.css?v=1">
+<link rel="stylesheet" href="/css/base.css?v=1">
+<link rel="stylesheet" href="/css/components.css?v=1">
+<link rel="stylesheet" href="/css/utilities.css?v=1">
 </head>
 <body data-active-tab="Beauty">
 
@@ -89,6 +89,6 @@
   <script src="/assets/js/product-card.js"></script>
   <script src="/assets/js/tabs.js"></script>
   <script src="/assets/js/whatsapp-fab.js"></script>
-<script src="./js/ui.js?v=1" defer></script>
+<script src="/js/ui.js?v=1" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- switch HTML pages to load shared CSS and UI script from the site root so nested routes don't request `/p` asset paths that 404

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static` *(reports broken links)*

------
https://chatgpt.com/codex/tasks/task_e_68aeefb84fb08320a0b931264f8653ab