### PR TITLE
Avoid duplicate StorefrontRuntime definition

### DIFF
--- a/assets/js/storefront-runtime.js
+++ b/assets/js/storefront-runtime.js
@@ -1,4 +1,5 @@
-const StorefrontRuntime = (() => {
+if (!window.StorefrontRuntime) {
+  window.StorefrontRuntime = (() => {
   let productsCache = null;
   let categoriesCache = null;
   const RECENT_KEY = 'recently_viewed';
@@ -134,4 +135,5 @@ const StorefrontRuntime = (() => {
     renderProductBadgesHTML,
     RECENT_KEY
   };
-})();
+  })();
+}


### PR DESCRIPTION
## Summary
- Prevent double-loading of `storefront-runtime.js` by checking for an existing `StorefrontRuntime` global before defining it.

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:static` (reports broken links)
- `npm run validate:data`


------
https://chatgpt.com/codex/tasks/task_e_68aef82698848320b39a90be0d4b6b56