### PR TITLE
Hide duplicate mobile CTA buttons

### DIFF
--- a/assets/css/pdp.css
+++ b/assets/css/pdp.css
@@ -79,6 +79,8 @@
 /* === PDP Mobile Fit (hardening) === */
 @media (max-width: 768px){
   .pdp{ overflow-x:hidden; }
+  .pdp__cta,
+  .pdp__cod-note{ display:none; }
 }
 .pdp__media, .pdp__main{ max-width:100%; }
 .pdp__main{ width:100%; }


### PR DESCRIPTION
## Summary
- Hide top Add to Cart / WhatsApp buttons and COD note on small screens to avoid duplicate mobile CTAs.

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:static`


------
https://chatgpt.com/codex/tasks/task_e_68af692ce8e08320b3dfaa767691306a