### PR TITLE
Remove hardcoded "All" tab from navigation

### DIFF
--- a/assets/js/tabs.js
+++ b/assets/js/tabs.js
@@ -70,12 +70,10 @@
       }catch{ return false; }
     }
 
-    // optional "All" tab pointing to home (matches reference)
-    const allTab = { id:'__all', name:'All', url: '/', order: -1, parent:null };
     const normalized = cats.map(normalize);
-    const uniq = uniqueBy(normalized, 'slug').sort((a,b)=> (a.order||0) - (b.order||0) || a.name.localeCompare(b.name));
-
-    const items = [allTab, ...uniq];
+    const items = uniqueBy(normalized, 'slug').sort(
+      (a,b)=> (a.order||0) - (b.order||0) || a.name.localeCompare(b.name)
+    );
 
     // Render
     nav.innerHTML = items.map(it => `


### PR DESCRIPTION
## Summary
- stop injecting a default "All" tab in the navigation; rely on category data instead

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:static`


------
https://chatgpt.com/codex/tasks/task_e_68af6cf3dc84832085f9ac8b35732e2f