### PR TITLE
Auto-scroll selected category tab into view

### DIFF
--- a/assets/js/tabs.js
+++ b/assets/js/tabs.js
@@ -81,6 +81,12 @@
         ${it.name}
       </a>
     `).join('');
+
+    // Ensure the active tab is visible in the scroll area
+    const activeTab = nav.querySelector('.bnz-tabs__item.is-active');
+    if (activeTab && typeof activeTab.scrollIntoView === 'function') {
+      activeTab.scrollIntoView({ block: 'nearest', inline: 'center' });
+    }
   }
 
 document.addEventListener('DOMContentLoaded', async function(){


### PR DESCRIPTION
## Summary
- ensure category tabs automatically scroll to display the active selection on smaller screens

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static`
- `npm run test:meta` *(fails: missing libXcomposite.so.1 despite installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68af6ea8c5a48320a2a9dae6c798f05a