### PR TITLE
Center tabs navigation on larger screens

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -72,7 +72,7 @@ a:hover{color:var(--brand-600); text-decoration:underline}
 .bnz-tabs{
   display:flex;
   align-items:center;
-  justify-content:flex-start;   /* keep first tabs visible on small screens */
+  justify-content:flex-start;   /* default left alignment; JS centers when overflow isn't needed */
   gap:12px;
   width:100%;
   margin:10px auto 18px;
@@ -82,7 +82,7 @@ a:hover{color:var(--brand-600); text-decoration:underline}
 }
 
 @media (min-width: 900px){
-  .bnz-tabs{
+  .bnz-tabs--center{
     justify-content:center;
   }
 }

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -72,13 +72,19 @@ a:hover{color:var(--brand-600); text-decoration:underline}
 .bnz-tabs{
   display:flex;
   align-items:center;
-  justify-content:flex-start;   /* keep first tabs visible */
+  justify-content:flex-start;   /* keep first tabs visible on small screens */
   gap:12px;
   width:100%;
   margin:10px auto 18px;
   padding:4px 0;
   overflow-x:auto;
   -webkit-overflow-scrolling:touch;
+}
+
+@media (min-width: 900px){
+  .bnz-tabs{
+    justify-content:center;
+  }
 }
 
 .bnz-tabs__item{

--- a/assets/js/tabs.js
+++ b/assets/js/tabs.js
@@ -89,6 +89,13 @@
     }
   }
 
+  function adjustTabsAlignment(){
+    const nav = document.querySelector('.bnz-tabs');
+    if (!nav) return;
+    const shouldCenter = window.innerWidth >= 900 && nav.scrollWidth <= nav.clientWidth;
+    nav.classList.toggle('bnz-tabs--center', shouldCenter);
+  }
+
 document.addEventListener('DOMContentLoaded', async function(){
     try{
       const raw = await loadCategories();
@@ -107,6 +114,8 @@ document.addEventListener('DOMContentLoaded', async function(){
     }catch(e){
       console.warn('tabs render error', e);
     }
+    adjustTabsAlignment();
+    window.addEventListener('resize', adjustTabsAlignment);
   });
 })();
 


### PR DESCRIPTION
## Summary
- center align `.bnz-tabs` navigation on viewports wider than 900px
- clarify comment about small-screen behavior

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:static`


------
https://chatgpt.com/codex/tasks/task_e_68af70e0ef9c8320990ecb6d1b499140