### PR TITLE
Remove account link from navigation icons

### DIFF
--- a/404.html
+++ b/404.html
@@ -56,7 +56,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>

--- a/about.html
+++ b/about.html
@@ -28,7 +28,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>

--- a/contact.html
+++ b/contact.html
@@ -28,7 +28,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>

--- a/cookie.html
+++ b/cookie.html
@@ -28,7 +28,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>

--- a/docs/how-to-choose-serum.html
+++ b/docs/how-to-choose-serum.html
@@ -26,7 +26,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>

--- a/faq.html
+++ b/faq.html
@@ -28,7 +28,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>

--- a/index-old.html
+++ b/index-old.html
@@ -30,7 +30,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>

--- a/privacy.html
+++ b/privacy.html
@@ -28,7 +28,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>

--- a/returns.html
+++ b/returns.html
@@ -28,7 +28,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>

--- a/scripts/tests/static-site-lint.js
+++ b/scripts/tests/static-site-lint.js
@@ -13,7 +13,7 @@ const categories = readJSON('assets/data/categories.json');
 const products = readJSON('assets/data/products.json');
 const catSlugs = new Set(categories.map(c => c.slug));
 const prodSlugs = new Set(products.map(p => p.slug));
-const dynamicPaths = new Set(['/account.html', '/wishlist.html', '/checkout.html']);
+const dynamicPaths = new Set(['/wishlist.html', '/checkout.html']);
 
 function walk(dir) {
   const res = [];

--- a/shipping.html
+++ b/shipping.html
@@ -28,7 +28,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>

--- a/terms.html
+++ b/terms.html
@@ -28,7 +28,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>

--- a/thank-you.html
+++ b/thank-you.html
@@ -31,7 +31,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>

--- a/track-order.html
+++ b/track-order.html
@@ -28,7 +28,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>

--- a/wishlist.html
+++ b/wishlist.html
@@ -28,7 +28,6 @@
         <input type="search" name="q" placeholder="Search">
         <button type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
       </form>
-      <a class="bnz-icon" href="/account.html" aria-label="Account"><i class="fa-regular fa-user"></i></a>
       <a class="bnz-icon" href="/wishlist.html" aria-label="Wishlist"><i class="fa-regular fa-heart"></i></a>
       <a class="bnz-icon" href="/cart.html" aria-label="Cart"><i class="fa-solid fa-bag-shopping"></i><span class="bnz-badge simpleCart_quantity">0</span></a>
     </div>


### PR DESCRIPTION
## Summary
- remove account icon link from site header across pages
- update static-site-lint dynamic paths to drop account page

## Testing
- `npm run validate:data`
- `npm run lint:static`
- `npm run test:sitemap`
- `npm run test:meta` *(fails: libatk-1.0.so.0 missing)*
- `npm run test:spa` *(fails: libatk-1.0.so.0 missing)*
- `npm run test:lighthouse` *(fails: ECONNREFUSED 127.0.0.1:45793)*
- `npm run test:features` *(fails: libatk-1.0.so.0 missing)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af7137e8848320a3f3d5fff60c97b9