### PR TITLE
Add My Orders page for cached orders and footer link

### DIFF
--- a/404.html
+++ b/404.html
@@ -82,6 +82,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>

--- a/about.html
+++ b/about.html
@@ -60,6 +60,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>

--- a/assets/css/orders.css
+++ b/assets/css/orders.css
@@ -1,0 +1,27 @@
+.orders-layout {
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.orders-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  padding: var(--space-8) var(--space-6);
+  max-width: 600px;
+  text-align: center;
+}
+
+.orders-icon {
+  font-size: 3rem;
+  color: var(--primary);
+  margin-bottom: var(--space-4);
+}
+
+#orders-list {
+  margin-top: var(--space-4);
+  text-align: left;
+}

--- a/c/index.html
+++ b/c/index.html
@@ -60,6 +60,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>

--- a/cart.cz.html
+++ b/cart.cz.html
@@ -99,6 +99,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>

--- a/cart.html
+++ b/cart.html
@@ -59,6 +59,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>

--- a/categories/index.html
+++ b/categories/index.html
@@ -54,6 +54,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>

--- a/contact.html
+++ b/contact.html
@@ -71,6 +71,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>

--- a/docs/how-to-choose-serum.html
+++ b/docs/how-to-choose-serum.html
@@ -49,6 +49,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>

--- a/faq.html
+++ b/faq.html
@@ -62,6 +62,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>

--- a/index-old.html
+++ b/index-old.html
@@ -146,6 +146,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>

--- a/orders.html
+++ b/orders.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cookie Policy - 4D Cosmetics</title>
+  <title>My Orders - 4D Cosmetics</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/css/tokens.css">
   <link rel="stylesheet" href="/assets/css/bootstrap.min.css">
@@ -12,10 +12,12 @@
   <link rel="stylesheet" href="/assets/css/theme.css">
   <link rel="stylesheet" href="/assets/css/product-card.css">
   <link rel="stylesheet" href="/assets/css/bonanza-layout.css">
+  <link rel="stylesheet" href="/assets/css/cart.css">
+  <link rel="stylesheet" href="/assets/css/checkout.css">
   <link rel="stylesheet" href="/assets/css/bonanza-overrides.css">
+  <link rel="stylesheet" href="/assets/css/orders.css">
 </head>
 <body data-active-tab="Beauty">
-
 <div class="annc" role="region" aria-label="Site announcement">
   <div class="container-narrow annc__inner">No Return or Exchange on Sale Items</div>
 </div>
@@ -37,22 +39,16 @@
   </nav>
 </header>
 
-  <section class="py-5">
-    <div class="container">
-      <a href="/" class="d-inline-block mb-3">← Back to shopping</a>
-      <h1 class="mb-4">Cookie Policy</h1>
-      <p>We use cookies to improve your experience. Cookies fall into these categories:</p>
-      <ul>
-        <li><strong>Strictly necessary</strong> – essential for site function.</li>
-        <li><strong>Performance</strong> – help us measure usage.</li>
-        <li><strong>Functional</strong> – remember your preferences.</li>
-        <li><strong>Marketing</strong> – used for advertising.</li>
-      </ul>
-      <p>You can change your preferences at any time via the Manage Cookies link in the footer.</p>
-    </div>
-  </section>
+<main class="container orders-layout">
+  <div class="orders-card">
+    <div class="orders-icon"><i class="fa-solid fa-receipt"></i></div>
+    <h1>My Orders</h1>
+    <div id="orders-list"></div>
+    <a href="/" class="btn btn-primary mt-3">Continue shopping</a>
+  </div>
+</main>
 
-  <footer class="bnz-footer">
+<footer class="bnz-footer">
   <div class="container-narrow">
     <div class="bnz-footer__cols">
       <div>
@@ -83,15 +79,39 @@
     <div class="bnz-copy">© 4D Cosmetics</div>
   </div>
 </footer>
-  <script src="/assets/js/jquery-2.2.4.min.js"></script>
-  <script src="/assets/js/bootstrap.bundle.min.js"></script>
-  <script src="/assets/js/simpleCart.min.js"></script>
-  <script src="/assets/js/config.js"></script>
-  <script type="module" src="/assets/js/money.js"></script>
-  <script src="/assets/js/storefront-runtime.js"></script>
-  <script src="/assets/js/product-card.js"></script>
-  <script src="/assets/js/tabs.js"></script>
-  <script src="/assets/js/whatsapp-fab.js"></script>
-  <script src="/assets/js/header-affordance.js" defer></script>
+
+<script src="/assets/js/jquery-2.2.4.min.js"></script>
+<script src="/assets/js/bootstrap.bundle.min.js"></script>
+<script src="/assets/js/simpleCart.min.js"></script>
+<script src="/assets/js/config.js"></script>
+<script type="module" src="/assets/js/money.js"></script>
+<script src="/assets/js/storefront-runtime.js"></script>
+<script src="/assets/js/product-card.js"></script>
+<script src="/assets/js/tabs.js"></script>
+<script type="module">
+  const data = localStorage.getItem('4d-last-order');
+  const list = document.getElementById('orders-list');
+  if(data){
+    try {
+      const order = JSON.parse(data);
+      let html = `<p><strong>Order ID:</strong> ${order.id}</p>`;
+      if(order.items && Array.isArray(order.items)){
+        html += '<ul>' + order.items.map(i=>`<li>${i.name} × ${i.quantity} = ${moneyPKR(i.subtotal)}</li>`).join('') + '</ul>';
+        if(order.amount) html += `<p><strong>Total:</strong> ${moneyPKR(order.amount)}</p>`;
+      } else {
+        if(order.item) html += `<p><strong>Item:</strong> ${order.item}</p>`;
+        if(order.amount) html += `<p><strong>Total:</strong> ${moneyPKR(order.amount)}</p>`;
+      }
+      if(order.pm) html += `<p><strong>Payment method:</strong> ${order.pm === 'whatsappCod' ? 'WhatsApp COD' : order.pm}</p>`;
+      list.innerHTML = html;
+    } catch(e){
+      list.innerHTML = '<p>Unable to load your order.</p>';
+    }
+  } else {
+    list.innerHTML = '<p>No recent orders found.</p>';
+  }
+</script>
+<script src="/assets/js/whatsapp-fab.js"></script>
+<script src="/assets/js/header-affordance.js" defer></script>
 </body>
 </html>

--- a/p/index.html
+++ b/p/index.html
@@ -93,6 +93,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>

--- a/privacy.html
+++ b/privacy.html
@@ -56,6 +56,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>

--- a/returns.html
+++ b/returns.html
@@ -58,6 +58,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>

--- a/search/index.html
+++ b/search/index.html
@@ -76,6 +76,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>

--- a/shipping.html
+++ b/shipping.html
@@ -58,6 +58,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>

--- a/terms.html
+++ b/terms.html
@@ -56,6 +56,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>

--- a/thank-you.html
+++ b/thank-you.html
@@ -62,6 +62,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>

--- a/track-order.html
+++ b/track-order.html
@@ -57,6 +57,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>

--- a/wishlist.html
+++ b/wishlist.html
@@ -55,6 +55,7 @@
         <h4>INFORMATION</h4>
         <ul>
           <li><a href="/track-order.html">Track Your Order</a></li>
+          <li><a href="/orders.html">My Orders</a></li>
           <li><a href="/shipping.html">Shipping Information</a></li>
           <li><a href="/returns.html">Return & Exchange Policy</a></li>
         </ul>


### PR DESCRIPTION
## Summary
- create `orders.html` to show the most recent order from browser cache
- style the new page with `orders.css`
- link the new My Orders page in footer Information section across the site

## Testing
- `npm run lint:static`
- `npm run test:meta` (fails: Category with image missing og:image, Product schema missing offers, Filtered category missing canonical, Filtered category missing grid, Deep-link filter not pre-selected)
- `npm run test:sitemap`
- `npm run test:spa`
- `npm run test:lighthouse`
- `npm run test:features` (fails: Search results missing cards, Autocomplete navigation failed, Recently viewed section missing, Out of stock badge missing, Category page cards incomplete, Product page missing cart hooks, Analytics threw without gtag)

------
https://chatgpt.com/codex/tasks/task_e_68af7274922483209921303503dfa39c