### PR TITLE
feat: style cart lines as Bootstrap card

### DIFF
--- a/assets/css/cart.css
+++ b/assets/css/cart.css
@@ -252,3 +252,13 @@ main.container{width:100%;max-width:1120px;margin:0 auto;padding:0 var(--space-4
 
 .cart-summary .row{ justify-content:space-between; gap:12px; margin:8px 0; }
 .cart-summary .row.total{ font-weight:700; font-size:var(--font-size-500); }
+
+/* Cart lines container card */
+.cart .card{
+  border:1px solid var(--border);
+  border-radius:12px;
+  background:var(--surface);
+}
+.cart .card .card-body{
+  padding:var(--space-4);
+}

--- a/cart.html
+++ b/cart.html
@@ -38,9 +38,11 @@
 </header>
 
   <main class="container bnz-main cart" id="main">
-    <section>
-      <h1>Your Cart</h1>
-      <div id="cart-lines"></div>
+    <section class="card">
+      <div class="card-body">
+        <h1 class="card-title mb-3">Your Cart</h1>
+        <div id="cart-lines" class="cart-lines"></div>
+      </div>
     </section>
     <aside class="cart-summary">
       <div class="row"><span>Subtotal</span><span id="cart-subtotal">—</span></div>


### PR DESCRIPTION
## Summary
- wrap cart item section in a Bootstrap card for improved spacing and responsiveness
- refine card styling to match site theme and ensure consistent cart line spacing

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static`


------
https://chatgpt.com/codex/tasks/task_e_68af76bfd12083208cf6dab8d8f06908