### PR TITLE
feat: update brand palette

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -2,7 +2,7 @@
   /* colors */
   --bg:#ffffff; --bg-alt:#fafafa;
   --text:#222; --muted:#666; --border:#eee;
-  --brand:#E91E63; --brand-600:#C2185B;
+  --brand:#1E88E5; --brand-600:#1565C0;
   --accent:#FF5252; --success:#43A047; --warning:#FB8C00; --sale:#D32F2F; --badge:#111;
 
   /* type & sizing */

--- a/assets/css/tokens.css
+++ b/assets/css/tokens.css
@@ -2,7 +2,7 @@
   --on-surface: #1F2937;
   --on-brand: #FFFFFF;
   --info: #1E88E5;
-  --brand-50: #FFF1F5;
+  --brand-50: #E3F2FD;
   /* Colors (light theme) */
   --bg: #FFFFFF;
   --surface: #FAFAFA;
@@ -111,8 +111,8 @@ input, select, textarea{
   --text:#1F2937;
   --muted:#6B7280;
   --border:#E5E7EB;
-  --brand:#E91E63;
-  --brand-600:#C2185B;
+  --brand:#1E88E5;
+  --brand-600:#1565C0;
   --accent:#FB8C00;
   --success:#43A047;
   --warning:#FB8C00;


### PR DESCRIPTION
## Summary
- align brand color variables with site's blue theme
- introduce light and dark shades for consistent hover and badge styling

## Testing
- `npm run lint:static`


------
https://chatgpt.com/codex/tasks/task_e_68af7ae294a083209cdfaac0aa1a2a78