### PR TITLE
Store all orders and list them on Orders page

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -1,5 +1,14 @@
 import { Payments } from './payments.js';
 
+function cacheOrder(order){
+  localStorage.setItem('4d-last-order', JSON.stringify(order));
+  try{
+    const all = JSON.parse(localStorage.getItem('4d-orders') || '[]');
+    all.push(order);
+    localStorage.setItem('4d-orders', JSON.stringify(all));
+  }catch(_){/* noop */}
+}
+
 const Checkout = {
   config: null,
   async init(){
@@ -34,14 +43,14 @@ const Checkout = {
       const res = await adapter.start(order, providerCfg, returnUrls);
       if(method === 'whatsappCod' && res.redirectUrl){
         order.id = order.id || (`ORD-${Date.now()}`);
-        localStorage.setItem('4d-last-order', JSON.stringify(order));
+        cacheOrder(order);
         const redirectUrl = res.redirectUrl;
         window.open(redirectUrl, '_blank');
         const success = (returnUrls?.success) || `/thank-you.html?oid=${encodeURIComponent(order.id)}&pm=whatsappCod`;
         window.location.href = success;
       } else {
         order.id = order.id || (`ORD-${Date.now()}`);
-        localStorage.setItem('4d-last-order', JSON.stringify(order));
+        cacheOrder(order);
         if(res.redirectUrl){
           const successUrl = (this.config && this.config.returnUrls && this.config.returnUrls.success)
             ? `${this.config.returnUrls.success}?oid=${encodeURIComponent(order.id)}`

--- a/assets/js/pdp-hydrate.js
+++ b/assets/js/pdp-hydrate.js
@@ -211,7 +211,11 @@
         window.open(waUrl, '_blank');
         try {
           var oid = 'ORD-' + Date.now();
-          localStorage.setItem('4d-last-order', JSON.stringify({ id: oid, pm:'whatsappCod', item:(p.title||p.name||'') }));
+          var order = { id: oid, pm:'whatsappCod', item:(p.title||p.name||'') };
+          localStorage.setItem('4d-last-order', JSON.stringify(order));
+          var all = JSON.parse(localStorage.getItem('4d-orders') || '[]');
+          all.push(order);
+          localStorage.setItem('4d-orders', JSON.stringify(all));
         } catch(_){}
         window.location.href = '/thank-you.html?pm=whatsappCod';
       });

--- a/orders.html
+++ b/orders.html
@@ -89,12 +89,20 @@
 <script src="/assets/js/product-card.js"></script>
 <script src="/assets/js/tabs.js"></script>
 <script type="module">
-  const data = localStorage.getItem('4d-last-order');
   const list = document.getElementById('orders-list');
-  if(data){
+  let orders = [];
+  try {
+    orders = JSON.parse(localStorage.getItem('4d-orders') || '[]');
+  } catch(_) {}
+  if(!orders.length){
     try {
-      const order = JSON.parse(data);
-      let html = `<p><strong>Order ID:</strong> ${order.id}</p>`;
+      const last = localStorage.getItem('4d-last-order');
+      if(last) orders = [JSON.parse(last)];
+    } catch(_) {}
+  }
+  if(orders.length){
+    list.innerHTML = orders.map(order => {
+      let html = `<div class="order"><p><strong>Order ID:</strong> ${order.id}</p>`;
       if(order.items && Array.isArray(order.items)){
         html += '<ul>' + order.items.map(i=>`<li>${i.name} × ${i.quantity} = ${moneyPKR(i.subtotal)}</li>`).join('') + '</ul>';
         if(order.amount) html += `<p><strong>Total:</strong> ${moneyPKR(order.amount)}</p>`;
@@ -103,12 +111,11 @@
         if(order.amount) html += `<p><strong>Total:</strong> ${moneyPKR(order.amount)}</p>`;
       }
       if(order.pm) html += `<p><strong>Payment method:</strong> ${order.pm === 'whatsappCod' ? 'WhatsApp COD' : order.pm}</p>`;
-      list.innerHTML = html;
-    } catch(e){
-      list.innerHTML = '<p>Unable to load your order.</p>';
-    }
+      html += '</div>';
+      return html;
+    }).join('<hr>');
   } else {
-    list.innerHTML = '<p>No recent orders found.</p>';
+    list.innerHTML = '<p>No orders found.</p>';
   }
 </script>
 <script src="/assets/js/whatsapp-fab.js"></script>


### PR DESCRIPTION
## Summary
- Persist every order in a `4d-orders` array in `localStorage` alongside the most recent order
- Record WhatsApp COD purchases in the same order history
- Render the full cached order list on `orders.html`

## Testing
- `npm run lint:static`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af7bd758dc8320a09b220c56aaa7ee