### PR TITLE
Hide WhatsApp FAB when mobile ATC bar is present

### DIFF
--- a/assets/js/whatsapp-fab.js
+++ b/assets/js/whatsapp-fab.js
@@ -1,6 +1,7 @@
 (function(){
   const raw = (document.documentElement?.dataset?.whatsapp || window.__SHOP_WHATSAPP__ || '').replace(/\D/g,'');
   if(!raw) return;
+  if(document.querySelector('.mobile-atc')) return;
   const href = `https://wa.me/${raw}`;
   const a = document.createElement('a');
   a.href = href;


### PR DESCRIPTION
## Summary
- Avoid showing the floating WhatsApp button on pages that contain the mobile add-to-cart bar

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static`


------
https://chatgpt.com/codex/tasks/task_e_68af7f03c3088320a3b915e9f0919944