### PR TITLE
Update shipping page with Pakistan-specific details

### DIFF
--- a/shipping.html
+++ b/shipping.html
@@ -37,14 +37,36 @@
   </nav>
 </header>
 
-  <section class="py-5">
-    <div class="container">
-      <a href="/" class="d-inline-block mb-3">← Back to shopping</a>
-      <h1 class="mb-4">Shipping & Delivery</h1>
-      <p>We ship across the EU using trusted carriers. Orders are processed within 1-2 business days and delivery typically takes 2-5 days.</p>
-      <p>Shipping is free on orders over €50. Once dispatched, you'll receive a tracking link via email.</p>
-      <p>If a parcel is damaged or lost, contact us so we can assist.</p>
-    </div>
+  <section id="shipping" class="shipping container">
+  <h1>Shipping & Delivery</h1>
+
+  <p>We aim to get your order to you quickly and safely, anywhere in Pakistan.</p>
+
+  <h2>Standard Delivery</h2>
+  <ul>
+    <li><strong>Flat rate:</strong> PKR 250 on all orders.</li>
+    <li><strong>Coverage:</strong> Delivery <em>within Pakistan only</em>.</li>
+    <li><strong>Timeline:</strong> 3–5 working days via trusted courier services.</li>
+    <li><strong>Tracking:</strong> Once dispatched, you’ll receive an email with your tracking details so you can monitor your parcel.</li>
+  </ul>
+
+  <h2>Urgent / Same-Day (ISB/Rawalpindi)</h2>
+  <ul>
+    <li>For urgent deliveries within Islamabad/Rawalpindi, we can arrange riders via <strong>inDrive</strong> or <strong>Yango</strong>.</li>
+    <li><strong>Charges:</strong> Actual inDrive/Yango fare is paid by the customer.</li>
+  </ul>
+
+  <h2>Support & Communication</h2>
+  <ul>
+    <li>We’ll keep you updated by email after dispatch.</li>
+    <li>Need help or want to coordinate urgent delivery? Reach us on WhatsApp: 
+      <a href="https://wa.me/92XXXXXXXXXX" aria-label="WhatsApp support">+92&nbsp;XX&nbsp;XXXX&nbsp;XXXX</a>.
+    </li>
+  </ul>
+
+  <p class="note">
+    <em>Note:</em> “Working days” refer to business days. Delivery times may vary due to courier operations, weather, or public holidays.
+  </p>
   </section>
 
   <footer class="bnz-footer">


### PR DESCRIPTION
## Summary
- replace shipping content with detailed Pakistan delivery info: flat PKR 250 rate, nationwide coverage, urgent inDrive/Yango options, and WhatsApp support

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:static`


------
https://chatgpt.com/codex/tasks/task_e_68b423eb818483208242d8aadfa1c029