### PR TITLE
feat: enable add-to-cart from product listings

### DIFF
--- a/assets/css/bonanza-home.css
+++ b/assets/css/bonanza-home.css
@@ -39,7 +39,6 @@
 .pc__price .price--new{ font-weight:800; }
 .pc__price .price--old{ font-size:13px; opacity:.75; text-decoration:line-through; }
 .pc__rating{ order:3; }
-.pc__cta{ display:none; } /* hide pink CTA on grid to match simpler reference */
 .pc__badges{ top:12px; left:12px; }
 .pc-badge{ border-radius:2px; text-transform:uppercase; font-size:10px; padding:3px 6px; }
 .pc-badge--best{ background:#b30000; } /* diagonal ribbon will be done via pseudo if needed */

--- a/assets/css/bonanza-layout.css
+++ b/assets/css/bonanza-layout.css
@@ -27,7 +27,6 @@
 .pc__price{ font-weight:800; }
 .pc__price .price--new{ font-weight:800; }
 .pc__price .price--old{ font-size:13px; opacity:.75; text-decoration:line-through; }
-.pc__cta{ display:none; }
 .pc__badges{ top:12px; left:12px; }
 .pc-badge{ border-radius:2px; text-transform:uppercase; font-size:10px; padding:3px 6px; }
 .pc-badge--best{ background:#b30000; }

--- a/assets/css/product-card.css
+++ b/assets/css/product-card.css
@@ -158,7 +158,7 @@
 
 /* CTA area pinned to bottom if used */
 .pc__cta{ margin-top: auto; display:flex; gap:8px; }
-.pc__cta .btn-modern{ min-height:40px; }
+.pc__cta .btn-modern{ min-height:40px; width:100%; display:flex; align-items:center; justify-content:center; gap:6px; }
 
 
 .badge-warning{ background:var(--danger); color:var(--on-brand); }

--- a/assets/js/product-card.js
+++ b/assets/js/product-card.js
@@ -1,6 +1,7 @@
 // exports: renderProductCard(item), formatPrice(number, currency)
 (function(global){
   const WISHLIST_KEY = 'wishlist_ids_v1';
+  const ITEM_CACHE = {};
 
   function loadWishlist(){
     try{ return JSON.parse(localStorage.getItem(WISHLIST_KEY) || '[]'); }catch{ return []; }
@@ -49,6 +50,7 @@
   function renderProductCard(raw){
     // Accept multiple shapes; normalize to a single item schema
     const item = normalize(raw);
+    ITEM_CACHE[item.id] = item;
     const FALLBACK_IMG = 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400"><rect width="100%" height="100%" fill="%23f3f3f3"/><text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="%23999" font-size="18">No image</text></svg>';
     const mainImg = item.image || FALLBACK_IMG;
     const imgAlt = item.image ? escapeHtml(item.image_alt || item.title) : 'No image available';
@@ -93,7 +95,10 @@
             ${priceOld ? `<span class="price price--old">${priceOld}</span>` : ''}
           </div>
           <div class="pc__cta">
-            <button class="btn-modern btn-modern--primary pc__atc" data-id="${item.id}" ${atcAttrs}>${atcLabel}</button>
+            <button class="btn-modern btn-modern--primary pc__atc" data-id="${item.id}" ${atcAttrs}>
+              <i class="fa-solid fa-bag-shopping" aria-hidden="true"></i>
+              <span>${atcLabel}</span>
+            </button>
           </div>
         </div>
       </article>
@@ -149,6 +154,35 @@
       atc.dispatchEvent(evt);
     }
   });
+
+  document.addEventListener('product:addToCart', (e)=>{
+    const id = e.detail && e.detail.id;
+    const qty = (e.detail && e.detail.qty) || 1;
+    const item = ITEM_CACHE[id];
+    if(!item) return;
+    try{
+      if(typeof simpleCart !== 'undefined'){
+        simpleCart.add({
+          id: id,
+          name: item.title,
+          price: item.price.current,
+          quantity: qty
+        });
+      }
+    }catch(err){ console.warn('cart error', err); }
+    showAddedToast(item.title);
+  });
+
+  function showAddedToast(name){
+    const toast = document.createElement('div');
+    toast.className = 'toast-notice position-fixed bottom-0 end-0 m-3 p-2 bg-dark text-white rounded';
+    toast.style.zIndex = '1055';
+    toast.innerHTML = `Added ${escapeHtml(name)} — <a href="/cart.html" class="text-white text-decoration-underline">View cart</a>`;
+    toast.setAttribute('role','status');
+    toast.setAttribute('aria-live','polite');
+    document.body.appendChild(toast);
+    setTimeout(()=>toast.remove(),3000);
+  }
 
   // expose
   global.ProductCard = { renderProductCard, formatPrice };


### PR DESCRIPTION
## Summary
- show a cart button on product cards with a bag icon
- handle product:addToCart events to add items to SimpleCart and show a toast
- style call-to-action buttons to span full card width
- ensure add-to-cart buttons appear on category pages by removing layout CSS that hid them

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:static`


------
https://chatgpt.com/codex/tasks/task_e_68bb3859c79083208abc932d9a409c95