### PR TITLE
Fix missing add-to-cart toast on product page

### DIFF
--- a/assets/js/pdp-hydrate.js
+++ b/assets/js/pdp-hydrate.js
@@ -164,6 +164,7 @@
           }
         }catch(e){ console.warn('cart error', e); }
         document.dispatchEvent(new CustomEvent('product:addToCart',{detail:{id:p.id||p.slug,qty:1}}));
+        if(typeof showAddedToast === 'function') showAddedToast(p.name);
       });
     });
   }

--- a/assets/js/pdp.js
+++ b/assets/js/pdp.js
@@ -47,6 +47,7 @@
       }
     }catch(e){ console.warn('cart error', e); }
     document.dispatchEvent(new CustomEvent('product:addToCart', { detail:{ id: product.id || product.slug, qty: qty||1 }}));
+    if(typeof showAddedToast === 'function') showAddedToast(product.name || product.title);
   }
   const atcButtons = document.querySelectorAll('[data-atc]');
   if(outOfStock){

--- a/assets/js/product-card.js
+++ b/assets/js/product-card.js
@@ -187,4 +187,5 @@
 
   // expose
   global.ProductCard = { renderProductCard, formatPrice };
+  if(!global.showAddedToast) global.showAddedToast = showAddedToast;
 })(window);


### PR DESCRIPTION
## Summary
- Expose `showAddedToast` globally for reuse across pages
- Trigger toast when adding to cart from product detail scripts

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static`


------
https://chatgpt.com/codex/tasks/task_e_68c0675ac1c48320baaed0217a16ce7c