### PR TITLE
feat: cache product images with service worker

### DIFF
--- a/assets/js/storefront-runtime.js
+++ b/assets/js/storefront-runtime.js
@@ -137,3 +137,8 @@ if (!window.StorefrontRuntime) {
   };
   })();
 }
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch(() => {});
+  });
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,31 @@
+const CACHE_NAME = 'image-cache-v1';
+
+self.addEventListener('install', event => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  const request = event.request;
+  if (request.destination === 'image') {
+    event.respondWith(
+      caches.open(CACHE_NAME).then(cache =>
+        cache.match(request).then(resp => {
+          if (resp) return resp;
+          return fetch(request).then(networkResp => {
+            cache.put(request, networkResp.clone());
+            return networkResp;
+          });
+        })
+      )
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add a service worker that caches all fetched images
- register the service worker on page load for site-wide image caching

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static`


------
https://chatgpt.com/codex/tasks/task_e_68c073a99090832083f019394b628c56