### PR TITLE
feat: replace cart toast with slide-in drawer

### DIFF
--- a/assets/css/cart-drawer.css
+++ b/assets/css/cart-drawer.css
@@ -1,0 +1,28 @@
+/* Basic styles for cart drawer */
+.cd__root { position: fixed; inset: 0; z-index: 1050; pointer-events:none; }
+.cd__backdrop { position: fixed; inset:0; background: rgba(0,0,0,0.3); opacity:0; transition:opacity .3s; pointer-events:auto; }
+.cd__panel { position: fixed; top:0; right:0; width:min(92vw,400px); height:100vh; background:#fff; box-shadow:-2px 0 8px rgba(0,0,0,.2); transform:translateX(100%); transition:transform .3s; display:flex; flex-direction:column; }
+.cd__panel.open { transform:translateX(0); }
+.cd__backdrop.open { opacity:1; }
+.cd__header { display:flex; justify-content:space-between; align-items:center; padding:1rem; border-bottom:1px solid #ddd; }
+.cd__items { flex:1; overflow:auto; padding:1rem; }
+.cd__item { display:flex; gap:.5rem; margin-bottom:1rem; }
+.cd__item-img { width:64px; height:64px; object-fit:cover; }
+.cd__qty { display:flex; align-items:center; gap:.25rem; }
+.cd__qty-btn { width:24px; height:24px; }
+.cd__qty-input { width:40px; text-align:center; }
+.cd__footer { padding:1rem; border-top:1px solid #ddd; display:flex; flex-direction:column; gap:.5rem; }
+.cd__btn { display:block; text-align:center; padding:.5rem; border:1px solid #444; background:#fff; text-decoration:none; }
+.cd__btn--primary { background:#000; color:#fff; }
+.cd__link { background:none; border:none; color:#333; text-decoration:underline; padding:0; }
+.cd__item--new { animation:cdGlow .3s; }
+@keyframes cdGlow { from { background:rgba(255,255,0,.4); } to { background:transparent; } }
+.cd__icon-bump { animation:cdBump .3s; }
+@keyframes cdBump { 50% { transform:scale(1.12); } }
+@media (max-width:768px){
+  .cd__panel { width:100%; bottom:0; top:auto; height:auto; max-height:90vh; border-top-left-radius:8px; border-top-right-radius:8px; transform:translateY(100%); }
+  .cd__panel.open { transform:translateY(0); }
+}
+@media (prefers-reduced-motion:reduce){
+  .cd__backdrop, .cd__panel, .cd__item--new, .cd__icon-bump { transition:none!important; animation:none!important; }
+}

--- a/assets/js/cart-drawer.js
+++ b/assets/js/cart-drawer.js
@@ -1,0 +1,196 @@
+// Cart Drawer module
+// Provides a slide-in mini cart drawer UI. Keeps existing cart logic intact.
+// Public API:
+// CartDrawer.init({ getCartState, updateQty, removeLineItem, undoLastAdd, checkoutUrl, viewCartUrl, onOpen, onClose, getProductById })
+// CartDrawer.open({ itemId, qty })
+// CartDrawer.update(cartState)
+// CartDrawer.close({ returnFocusTo } = {})
+// CartDrawer.bumpCartIcon()
+
+const CartDrawer = (() => {
+  let opts = {};
+  let root, backdrop, panel, itemsEl, subtotalEl, liveEl;
+  let isOpen = false;
+  let lastTrigger = null;
+  let lastAdded = null;
+  let undoStack = [];
+  let autoTimer = null;
+
+  function init(options = {}) {
+    if (root) return CartDrawer;
+    opts = options;
+    build();
+    document.addEventListener('product:addToCart', e => {
+      const d = e.detail || {};
+      open({ itemId: d.productId || d.id, qty: d.qty || 1 });
+    });
+    return CartDrawer;
+  }
+
+  function build() {
+    root = document.createElement('div');
+    root.className = 'cd__root';
+    root.innerHTML = `
+      <div class="cd__backdrop" hidden></div>
+      <aside class="cd__panel" role="dialog" aria-modal="true" aria-labelledby="cd_header" hidden>
+        <div class="cd__header"><span id="cd_header">Added to your cart</span><button class="cd__close" data-cd-close aria-label="Close">×</button></div>
+        <div class="cd__error" hidden></div>
+        <div class="cd__items"></div>
+        <div class="cd__footer">
+          <div class="cd__subtotal">Subtotal: <span class="cd__subtotal-val">0</span></div>
+          <button class="cd__undo cd__btn" data-cd-undo hidden>Undo</button>
+          <a class="cd__btn cd__btn--primary" data-cd-checkout href="#">Checkout</a>
+          <a class="cd__btn" data-cd-view href="#">View cart</a>
+          <button class="cd__link" data-cd-close>Continue shopping</button>
+        </div>
+      </aside>
+      <div class="sr-only" aria-live="polite" aria-atomic="true" id="cd_aria_live"></div>
+    `;
+    document.body.appendChild(root);
+    backdrop = root.querySelector('.cd__backdrop');
+    panel = root.querySelector('.cd__panel');
+    itemsEl = panel.querySelector('.cd__items');
+    subtotalEl = panel.querySelector('.cd__subtotal-val');
+    liveEl = root.querySelector('#cd_aria_live');
+
+    panel.querySelector('[data-cd-checkout]').href = opts.checkoutUrl || '/checkout';
+    panel.querySelector('[data-cd-view]').href = opts.viewCartUrl || '/cart';
+
+    backdrop.addEventListener('click', () => {
+      if (window.matchMedia('(min-width:769px)').matches) close();
+      else close();
+    });
+    panel.addEventListener('click', e => {
+      if (e.target.matches('[data-cd-close]')) { e.preventDefault(); close({ returnFocusTo: lastTrigger }); }
+      if (e.target.matches('[data-cd-undo]')) { e.preventDefault(); undo(); }
+      if (e.target.matches('.cd__qty-btn')) handleQty(e.target);
+      if (e.target.matches('.cd__remove')) handleRemove(e.target);
+    });
+    document.addEventListener('keydown', e => {
+      if (!isOpen) return;
+      if (e.key === 'Escape') { e.preventDefault(); close({ returnFocusTo: lastTrigger }); }
+    });
+  }
+
+  function focusTrap(e){
+    if (!isOpen || e.key !== 'Tab') return;
+    const focusables = panel.querySelectorAll('a,button,input');
+    if (!focusables.length) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length-1];
+    if (e.shiftKey && document.activeElement === first){ e.preventDefault(); last.focus(); }
+    else if(!e.shiftKey && document.activeElement === last){ e.preventDefault(); first.focus(); }
+  }
+
+  document.addEventListener('keydown', focusTrap);
+
+  function handleQty(btn){
+    const id = btn.closest('.cd__item').dataset.id;
+    const input = btn.closest('.cd__qty').querySelector('.cd__qty-input');
+    let val = Number(input.value)||1;
+    if (btn.dataset.dec) val = Math.max(1, val-1);
+    if (btn.dataset.inc) val = val+1;
+    input.value = val;
+    opts.updateQty && opts.updateQty(id, val).then(refresh).catch(()=>showLineError(id));
+  }
+
+  function handleRemove(btn){
+    const id = btn.closest('.cd__item').dataset.id;
+    opts.removeLineItem && opts.removeLineItem(id).then(refresh).catch(()=>showLineError(id));
+  }
+
+  function showLineError(id){
+    const row = itemsEl.querySelector(`[data-id="${id}"]`);
+    if(row) row.classList.add('cd__item--error');
+  }
+
+  function undo(){
+    const last = undoStack.pop();
+    if(!last) return;
+    if(opts.undoLastAdd){ opts.undoLastAdd().then(refresh); return; }
+    // fallback: decrement or remove
+    opts.updateQty && opts.updateQty(last.lineId, Math.max(0, last.qty-1)).then(refresh);
+  }
+
+  function announce(text){ if(liveEl) liveEl.textContent = text; }
+
+  async function refresh(){
+    const state = opts.getCartState ? await opts.getCartState() : {items:[],subtotal:0};
+    update(state);
+  }
+
+  function renderItems(items){
+    itemsEl.innerHTML = items.map(it=>`
+      <div class="cd__item" data-id="${it.id}">
+        <img src="${it.image}" alt="" class="cd__item-img"/>
+        <div class="cd__item-info">
+          <p class="cd__item-title">${it.title}</p>
+          ${it.variantTitle? `<p class="cd__item-variant">${it.variantTitle}</p>`:''}
+          <p class="cd__item-price">${formatMoney(it.price)}</p>
+          <div class="cd__qty">
+            <button class="cd__qty-btn" data-dec>-</button>
+            <input class="cd__qty-input" type="number" min="1" value="${it.qty}">
+            <button class="cd__qty-btn" data-inc>+</button>
+          </div>
+        </div>
+        <button class="cd__remove" aria-label="Remove">×</button>
+      </div>
+    `).join('');
+  }
+
+  function formatMoney(v){
+    try{ return window.moneyPKR ? moneyPKR(v) : v; }catch{return v;}
+  }
+
+  function update(cart){
+    renderItems(cart.items||[]);
+    subtotalEl.textContent = formatMoney(cart.subtotal||0);
+    if(lastAdded){
+      const row = itemsEl.querySelector(`[data-id="${lastAdded}"]`);
+      if(row){ row.classList.add('cd__item--new'); setTimeout(()=>row.classList.remove('cd__item--new'),300); }
+    }
+  }
+
+  async function open({ itemId, qty }){
+    lastTrigger = document.activeElement;
+    lastAdded = itemId;
+    isOpen = true;
+    panel.hidden = false;
+    backdrop.hidden = false;
+    panel.classList.add('open');
+    backdrop.classList.add('open');
+    announce('Added to your cart');
+    bumpCartIcon();
+    if(opts.onOpen) opts.onOpen();
+    await refresh();
+    const focusable = panel.querySelector('a,button,input');
+    focusable && focusable.focus();
+    if(window.matchMedia('(min-width:769px)').matches){
+      clearTimeout(autoTimer);
+      autoTimer = setTimeout(()=>{ if(isOpen) close(); },7000);
+    }
+    document.dispatchEvent(new CustomEvent('cartdrawer:opened',{detail:{source:'add_to_cart'}}));
+  }
+
+  function close({ returnFocusTo } = {}){
+    isOpen = false;
+    panel.classList.remove('open');
+    backdrop.classList.remove('open');
+    setTimeout(()=>{ panel.hidden = true; backdrop.hidden = true; },200);
+    clearTimeout(autoTimer);
+    if(opts.onClose) opts.onClose();
+    if(returnFocusTo){ try{ returnFocusTo.focus(); }catch{} }
+  }
+
+  function bumpCartIcon(){
+    const icon = document.querySelector('[data-cart-icon]');
+    const badge = document.querySelector('[data-cart-badge]');
+    if(icon){ icon.classList.add('cd__icon-bump'); setTimeout(()=>icon.classList.remove('cd__icon-bump'),300); }
+    if(badge){ badge.classList.add('cd__icon-bump'); setTimeout(()=>badge.classList.remove('cd__icon-bump'),300); }
+  }
+
+  return { init, open, update, close, bumpCartIcon };
+})();
+
+export { CartDrawer };
+

--- a/assets/js/pdp-hydrate.js
+++ b/assets/js/pdp-hydrate.js
@@ -10,6 +10,43 @@
   }
   var slug = detectSlug();
 
+  if(!window.cartApi && typeof simpleCart !== 'undefined'){
+    window.cartApi = {
+      async getCartState(){
+        const items = simpleCart.items().map(it=>({
+          id: it.id(),
+          productId: it.id(),
+          title: it.get('name'),
+          qty: it.quantity(),
+          price: Number(it.get('price'))||0,
+          image: it.get('image')||''
+        }));
+        const subtotal = items.reduce((s,it)=>s+it.price*it.qty,0);
+        return { items, subtotal };
+      },
+      updateQty(id,qty){ try{ simpleCart.find(id).set('quantity',qty); return Promise.resolve(); }catch(e){return Promise.reject(e);} },
+      removeLineItem(id){ try{ simpleCart.find(id).remove(); return Promise.resolve(); }catch(e){return Promise.reject(e);} },
+      undoLastAdd:null
+    };
+  }
+  if(!window.CartDrawer){
+    const s=document.createElement('script'); s.type='module'; s.src='/assets/js/cart-drawer.js';
+    s.onload=()=>{ window.CartDrawer && window.CartDrawer.init({
+      getCartState: window.cartApi?.getCartState,
+      updateQty: window.cartApi?.updateQty,
+      removeLineItem: window.cartApi?.removeLineItem,
+      undoLastAdd: window.cartApi?.undoLastAdd,
+      checkoutUrl:'/checkout', viewCartUrl:'/cart'
+    }); };
+    document.head.appendChild(s);
+    const link=document.createElement('link'); link.rel='stylesheet'; link.href='/assets/css/cart-drawer.css'; document.head.appendChild(link);
+  }
+
+  const iconHook = document.querySelector('[data-cart-icon]') || document.querySelector('.bnz-icon');
+  const badgeHook = document.querySelector('[data-cart-badge]') || document.querySelector('.simpleCart_quantity');
+  if(iconHook && !iconHook.hasAttribute('data-cart-icon')) iconHook.setAttribute('data-cart-icon','');
+  if(badgeHook && !badgeHook.hasAttribute('data-cart-badge')) badgeHook.setAttribute('data-cart-badge','');
+
   async function loadAllProducts(){
     try{ if (window.Storefront && typeof Storefront.getAllProducts === 'function'){ const r = await Storefront.getAllProducts(); if (Array.isArray(r)) return r; } }catch(e){}
     try{ if (window.Storefront && typeof Storefront.getAll === 'function'){ const r = await Storefront.getAll(); if (Array.isArray(r)) return r; } }catch(e){}
@@ -163,8 +200,7 @@
             simpleCart.add({ id: p.id || p.slug, name: p.name, price: p.price.current, quantity: 1, image: (p.images && p.images[0]) || '' });
           }
         }catch(e){ console.warn('cart error', e); }
-        document.dispatchEvent(new CustomEvent('product:addToCart',{detail:{id:p.id||p.slug,qty:1}}));
-        if(typeof showAddedToast === 'function') showAddedToast(p.name);
+        document.dispatchEvent(new CustomEvent('product:addToCart',{detail:{productId:p.id||p.slug,qty:1}}));
       });
     });
   }

--- a/assets/js/pdp.js
+++ b/assets/js/pdp.js
@@ -4,6 +4,43 @@
   if(!product) return;
   const outOfStock = product.inStock === false;
 
+  if(!window.cartApi && typeof simpleCart !== 'undefined'){
+    window.cartApi = {
+      async getCartState(){
+        const items = simpleCart.items().map(it=>({
+          id: it.id(),
+          productId: it.id(),
+          title: it.get('name'),
+          qty: it.quantity(),
+          price: Number(it.get('price'))||0,
+          image: it.get('image')||''
+        }));
+        const subtotal = items.reduce((s,it)=>s+it.price*it.qty,0);
+        return { items, subtotal };
+      },
+      updateQty(id,qty){ try{ simpleCart.find(id).set('quantity',qty); return Promise.resolve(); }catch(e){return Promise.reject(e);} },
+      removeLineItem(id){ try{ simpleCart.find(id).remove(); return Promise.resolve(); }catch(e){return Promise.reject(e);} },
+      undoLastAdd:null
+    };
+  }
+  if(!window.CartDrawer){
+    const s=document.createElement('script'); s.type='module'; s.src='/assets/js/cart-drawer.js';
+    s.onload=()=>{ window.CartDrawer && window.CartDrawer.init({
+      getCartState: window.cartApi?.getCartState,
+      updateQty: window.cartApi?.updateQty,
+      removeLineItem: window.cartApi?.removeLineItem,
+      undoLastAdd: window.cartApi?.undoLastAdd,
+      checkoutUrl:'/checkout', viewCartUrl:'/cart'
+    }); };
+    document.head.appendChild(s);
+    const link=document.createElement('link'); link.rel='stylesheet'; link.href='/assets/css/cart-drawer.css'; document.head.appendChild(link);
+  }
+
+  const iconHook = document.querySelector('[data-cart-icon]') || document.querySelector('.bnz-icon');
+  const badgeHook = document.querySelector('[data-cart-badge]') || document.querySelector('.simpleCart_quantity');
+  if(iconHook && !iconHook.hasAttribute('data-cart-icon')) iconHook.setAttribute('data-cart-icon','');
+  if(badgeHook && !badgeHook.hasAttribute('data-cart-badge')) badgeHook.setAttribute('data-cart-badge','');
+
   // Populate gallery
   const mainBox = document.querySelector('.pdp__main');
   const thumbs  = document.querySelector('.pdp__thumbs');
@@ -57,8 +94,8 @@
         });
       }
     }catch(e){ console.warn('cart error', e); }
-    document.dispatchEvent(new CustomEvent('product:addToCart', { detail:{ id: product.id || product.slug, qty: qty||1 }}));
-    if(typeof showAddedToast === 'function') showAddedToast(product.name || product.title);
+    const detail = { productId: product.id || product.slug, qty: qty||1 };
+    document.dispatchEvent(new CustomEvent('product:addToCart', { detail }));
   }
   const atcButtons = document.querySelectorAll('[data-atc]');
   if(outOfStock){

--- a/assets/js/product-card.js
+++ b/assets/js/product-card.js
@@ -3,6 +3,61 @@
   const WISHLIST_KEY = 'wishlist_ids_v1';
   const ITEM_CACHE = {};
 
+  // expose simpleCart based cart API for CartDrawer
+  if(!global.cartApi && typeof simpleCart !== 'undefined'){
+    global.cartApi = {
+      async getCartState(){
+        const items = simpleCart.items().map(it => ({
+          id: it.id(),
+          productId: it.id(),
+          title: it.get('name'),
+          qty: it.quantity(),
+          price: Number(it.get('price'))||0,
+          image: it.get('image') || ''
+        }));
+        const subtotal = items.reduce((s,it)=>s + it.price*it.qty,0);
+        return { items, subtotal };
+      },
+      updateQty(id, qty){
+        try{ simpleCart.find(id).set('quantity', qty); return Promise.resolve(); }
+        catch(e){ return Promise.reject(e); }
+      },
+      removeLineItem(id){
+        try{ simpleCart.find(id).remove(); return Promise.resolve(); }
+        catch(e){ return Promise.reject(e); }
+      },
+      undoLastAdd: null
+    };
+  }
+
+  // load cart drawer module once
+  if(!global.CartDrawer){
+    const s = document.createElement('script');
+    s.type = 'module';
+    s.src = '/assets/js/cart-drawer.js';
+    s.onload = () => {
+      global.CartDrawer && global.CartDrawer.init({
+        getCartState: global.cartApi?.getCartState,
+        updateQty: global.cartApi?.updateQty,
+        removeLineItem: global.cartApi?.removeLineItem,
+        undoLastAdd: global.cartApi?.undoLastAdd,
+        checkoutUrl: '/checkout',
+        viewCartUrl: '/cart'
+      });
+    };
+    document.head.appendChild(s);
+    const link=document.createElement('link');
+    link.rel='stylesheet';
+    link.href='/assets/css/cart-drawer.css';
+    document.head.appendChild(link);
+  }
+
+  // ensure cart icon hooks
+  const iconHook = document.querySelector('[data-cart-icon]') || document.querySelector('.bnz-icon');
+  const badgeHook = document.querySelector('[data-cart-badge]') || document.querySelector('.simpleCart_quantity');
+  if(iconHook && !iconHook.hasAttribute('data-cart-icon')) iconHook.setAttribute('data-cart-icon','');
+  if(badgeHook && !badgeHook.hasAttribute('data-cart-badge')) badgeHook.setAttribute('data-cart-badge','');
+
   function loadWishlist(){
     try{ return JSON.parse(localStorage.getItem(WISHLIST_KEY) || '[]'); }catch{ return []; }
   }
@@ -153,42 +208,25 @@
     if(atc){
       e.preventDefault(); e.stopPropagation();
       const id = atc.getAttribute('data-id');
-      const evt = new CustomEvent('product:addToCart', { detail: { id }, bubbles:true });
-      atc.dispatchEvent(evt);
+      const item = ITEM_CACHE[id];
+      if(!item) return;
+      try{
+        if(typeof simpleCart !== 'undefined'){
+          simpleCart.add({
+            id: id,
+            name: item.title,
+            price: item.price.current,
+            image: item.image,
+            quantity: 1
+          });
+        }
+      }catch(err){ console.warn('cart error', err); }
+      if(window.Analytics) window.Analytics.addToCart(item,1);
+      const detail = { productId: id, qty: 1 };
+      document.dispatchEvent(new CustomEvent('product:addToCart', { detail }));
     }
   });
 
-  document.addEventListener('product:addToCart', (e)=>{
-    const id = e.detail && e.detail.id;
-    const qty = (e.detail && e.detail.qty) || 1;
-    const item = ITEM_CACHE[id];
-    if(!item) return;
-    try{
-      if(typeof simpleCart !== 'undefined'){
-        simpleCart.add({
-          id: id,
-          name: item.title,
-          price: item.price.current,
-          image: item.image,
-          quantity: qty
-        });
-      }
-    }catch(err){ console.warn('cart error', err); }
-    showAddedToast(item.title);
-  });
-
-  function showAddedToast(name){
-    const toast = document.createElement('div');
-    toast.className = 'toast-notice position-fixed bottom-0 end-0 m-3 p-2 bg-dark text-white rounded';
-    toast.style.zIndex = '1055';
-    toast.innerHTML = `Added ${escapeHtml(name)} — <a href="/cart.html" class="text-white text-decoration-underline">View cart</a>`;
-    toast.setAttribute('role','status');
-    toast.setAttribute('aria-live','polite');
-    document.body.appendChild(toast);
-    setTimeout(()=>toast.remove(),3000);
-  }
-
   // expose
   global.ProductCard = { renderProductCard, formatPrice };
-  if(!global.showAddedToast) global.showAddedToast = showAddedToast;
 })(window);

--- a/assets/js/product-page.js
+++ b/assets/js/product-page.js
@@ -1,5 +1,39 @@
-import { normalizePrice, showAddedToast, Analytics } from './ui-cards.js';
+import { normalizePrice, Analytics } from './ui-cards.js';
 import { applySEO } from './seo.js';
+import { CartDrawer } from './cart-drawer.js';
+
+if(!window.cartApi && typeof simpleCart !== 'undefined'){
+  window.cartApi = {
+    async getCartState(){
+      const items = simpleCart.items().map(it=>({
+        id: it.id(),
+        productId: it.id(),
+        title: it.get('name'),
+        qty: it.quantity(),
+        price: Number(it.get('price'))||0,
+        image: it.get('image')||''
+      }));
+      const subtotal = items.reduce((s,it)=>s+it.price*it.qty,0);
+      return { items, subtotal };
+    },
+    updateQty(id,qty){ try{ simpleCart.find(id).set('quantity',qty); return Promise.resolve(); }catch(e){return Promise.reject(e);} },
+    removeLineItem(id){ try{ simpleCart.find(id).remove(); return Promise.resolve(); }catch(e){return Promise.reject(e);} },
+    undoLastAdd:null
+  };
+}
+CartDrawer.init({
+  getCartState: window.cartApi?.getCartState,
+  updateQty: window.cartApi?.updateQty,
+  removeLineItem: window.cartApi?.removeLineItem,
+  undoLastAdd: window.cartApi?.undoLastAdd,
+  checkoutUrl: '/checkout',
+  viewCartUrl: '/cart'
+});
+const cdLink=document.createElement('link');cdLink.rel='stylesheet';cdLink.href='/assets/css/cart-drawer.css';document.head.appendChild(cdLink);
+const iconHook=document.querySelector('[data-cart-icon]')||document.querySelector('.bnz-icon');
+const badgeHook=document.querySelector('[data-cart-badge]')||document.querySelector('.simpleCart_quantity');
+if(iconHook && !iconHook.hasAttribute('data-cart-icon')) iconHook.setAttribute('data-cart-icon','');
+if(badgeHook && !badgeHook.hasAttribute('data-cart-badge')) badgeHook.setAttribute('data-cart-badge','');
 
 document.addEventListener('DOMContentLoaded', async () => {
   const parts = window.location.pathname.split('/').filter(Boolean);
@@ -190,7 +224,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         const item = currentVariant ? {...product, ...currentVariant} : product;
         Analytics.addToCart(item, qty);
         if (liveRegion) liveRegion.textContent = 'Added to cart';
-        showAddedToast(item.name);
+        const detail = { productId: item.id || item.slug, qty };
+        document.dispatchEvent(new CustomEvent('product:addToCart', { detail }));
       });
     }
     const mobileBtn = document.getElementById('mobile-atc-btn');

--- a/assets/js/ui-cards.js
+++ b/assets/js/ui-cards.js
@@ -41,18 +41,6 @@ export const Analytics = {
   }
 };
 
-// toast helper
-export function showAddedToast(name) {
-  const toast = document.createElement('div');
-  toast.className = 'toast-notice position-fixed bottom-0 end-0 m-3 p-2 bg-dark text-white rounded';
-  toast.style.zIndex = '1055';
-  toast.innerHTML = `Added ${name} — <a href="/cart.html" class="text-white text-decoration-underline">View cart</a>`;
-  toast.setAttribute('role', 'status');
-  toast.setAttribute('aria-live', 'polite');
-  document.body.appendChild(toast);
-  setTimeout(() => toast.remove(), 3000);
-}
-
 // Normalize price to a number. Returns null if invalid.
 export function normalizePrice(val) {
   if (val && typeof val === 'object') val = val.current;
@@ -116,7 +104,8 @@ export function buildProductCard(prod) {
     const btn = wrap.querySelector('.item_add');
     btn.addEventListener('click', () => {
       Analytics.addToCart(prod, 1);
-      showAddedToast(prod.name);
+      const detail = { productId: prod.id || prod.slug, qty: 1 };
+      document.dispatchEvent(new CustomEvent('product:addToCart', { detail }));
     });
   }
   wrap.querySelectorAll('a[href^="/p/"]').forEach(a => {
@@ -127,7 +116,6 @@ export function buildProductCard(prod) {
 
 // expose helpers globally
 window.Analytics = Analytics;
-window.showAddedToast = showAddedToast;
 
 // --- appended modern product card integration ---
 // Override buildProductCard to use ProductCard component
@@ -145,22 +133,6 @@ buildProductCard = function(prod){
   const link = el.querySelector('.pc__link');
   link?.addEventListener('click', () => Analytics.selectItem(prod));
 
-  // cart and analytics on add to cart
-  const priceNum = normalizePrice(prod.price);
-  el.addEventListener('product:addToCart', () => {
-    try{
-      if(typeof simpleCart !== 'undefined' && priceNum !== null){
-        simpleCart.add({
-          id: prod.id || prod.slug,
-          name: prod.name,
-          price: priceNum,
-          image: (prod.images && prod.images[0]) || prod.image || '',
-          quantity: 1
-        });
-      }
-    }catch(e){ console.warn('cart error', e); }
-    Analytics.addToCart(prod, 1);
-    showAddedToast(prod.name);
-  });
+  // cart and analytics handled globally by product-card.js
   return el;
 };


### PR DESCRIPTION
## Summary
- introduce `CartDrawer` module and styles for slide-in cart drawer
- emit `product:addToCart` events and remove old toast notifications
- wire cart API adapters and initialization across product scripts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c078e305bc832094597e88445b53b0