### PR TITLE
Fix hero banner spacing on mobile

### DIFF
--- a/about.html
+++ b/about.html
@@ -37,7 +37,7 @@
   </nav>
 </header>
 
-  <section class="hero" style="background-image:url('https://images.unsplash.com/photo-1500839941678-aae14dbfae9e?auto=format&fit=crop&w=1200&q=80');">
+  <section class="hero hero--full" style="background-image:url('https://images.unsplash.com/photo-1500839941678-aae14dbfae9e?auto=format&fit=crop&w=1200&q=80');">
     <div class="container">
       <h1>About 4D Cosmetics</h1>
     </div>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -53,12 +53,17 @@ footer a:hover { text-decoration: underline; }
   overflow: hidden;
   color: var(--primary-contrast);
   text-align: center;
+}
+
+/* Only apply a tall minimum height when explicitly requested */
+.hero--full {
   min-height: 60vh;
 }
 
 .hero-img {
   width: 100%;
   height: auto;
+  display: block;
   object-fit: cover;
   aspect-ratio: 16/9;
 }

--- a/index-old.html
+++ b/index-old.html
@@ -40,7 +40,7 @@
 </header>
 
   <main id="main">
-    <section class="hero">
+    <section class="hero hero--full">
       <img src="https://images.unsplash.com/photo-1522335789203-aabd1fc54bc9?auto=format&fit=crop&w=1200&q=80" alt="Assorted cosmetics displayed on a table" class="hero-img" width="1200" height="600" loading="eager" fetchpriority="high">
       <div class="hero-content">
         <h1>Beauty in Four Dimensions</h1>


### PR DESCRIPTION
## Summary
- avoid unwanted whitespace below hero images by separating full-height hero class
- display hero images as block elements to remove baseline gap
- update pages with background heroes to use the new `hero--full` style

## Testing
- `npm run lint:static`


------
https://chatgpt.com/codex/tasks/task_e_68c082d7283083208228f07aebd1407a