### PR TITLE
Remove View cart button from cart drawer

### DIFF
--- a/assets/js/cart-drawer.js
+++ b/assets/js/cart-drawer.js
@@ -90,7 +90,7 @@
 
   const state = {
     api: defaultApi,
-    opts: { viewCartUrl:'/cart.html', checkoutUrl:'/cart.html' },
+    opts: { checkoutUrl:'/cart.html' },
     root: null,
     lastTrigger: null,
     autoCloseTimer: null
@@ -134,7 +134,6 @@
         <footer class="cart-drawer-footer">
           <div class="row"><span>Subtotal</span><span id="summary-subtotal">—</span></div>
           <div class="cart-drawer-actions">
-            <a class="btn btn-outline-secondary" href="${state.opts.viewCartUrl}">View cart</a>
             <a class="btn btn-primary" href="${state.opts.checkoutUrl}">Checkout</a>
           </div>
         </footer>


### PR DESCRIPTION
## Summary
- remove View cart button from the cart drawer footer
- drop unused viewCartUrl option

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static`


------
https://chatgpt.com/codex/tasks/task_e_68c09e102a948320b340793eb2009982