### PR TITLE
Show cart drawer scrollable content indicator

### DIFF
--- a/assets/css/cart-drawer.css
+++ b/assets/css/cart-drawer.css
@@ -7,7 +7,7 @@
 
 .cart-drawer-header{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;border-bottom:1px solid #eee;}
 .cart-drawer-title{font-size:1.125rem;margin:0;}
-.cart-drawer-body{padding:12px 16px;overflow:auto;flex:1;contain:content;}
+.cart-drawer-body{padding:12px 16px;overflow:auto;flex:1;contain:content;position:relative;}
 .cart-drawer-footer{border-top:1px solid #eee;padding:12px 16px;}
 
 .cart-drawer-empty{padding:24px 8px;color:#666;text-align:center;}
@@ -45,3 +45,9 @@
 .cart-drawer-panel{pointer-events:auto; overflow:hidden;}
 .cart-drawer-body{overflow-y:auto; overflow-x:hidden; -webkit-overflow-scrolling:touch;}
 .cart-drawer-actions .btn{pointer-events:auto;}
+
+.cart-drawer-body::before,.cart-drawer-body::after{content:"";position:sticky;left:0;right:0;height:24px;pointer-events:none;z-index:1;opacity:0;transition:opacity .2s;}
+.cart-drawer-body::before{top:0;background:linear-gradient(#fff,rgba(255,255,255,0));}
+.cart-drawer-body::after{bottom:0;background:linear-gradient(to top,#fff,rgba(255,255,255,0));}
+.cart-drawer-body.scroll-top::before{opacity:1;}
+.cart-drawer-body.scroll-bottom::after{opacity:1;}

--- a/assets/js/cart-drawer.js
+++ b/assets/js/cart-drawer.js
@@ -178,6 +178,9 @@
       if(qty){ const id = qty.dataset.qty; const v = Math.max(1, parseInt(qty.value||'1',10)); state.api.updateQty(id, v); render(); }
     });
 
+    const body = root.querySelector('.cart-drawer-body');
+    if(body){ body.addEventListener('scroll', updateScrollIndicators); }
+
     // Basic focus trap
     root.addEventListener('keydown', (e)=>{
       if(e.key === 'Escape') { e.preventDefault(); CartDrawer.close(); }
@@ -225,6 +228,16 @@
     return t.content.firstElementChild;
   }
 
+  function updateScrollIndicators(){
+    if(!state.root) return;
+    var body = state.root.querySelector('.cart-drawer-body');
+    if(!body) return;
+    var atTop = body.scrollTop <= 0;
+    var atBottom = body.scrollTop + body.clientHeight >= body.scrollHeight - 1;
+    body.classList.toggle('scroll-top', !atTop);
+    body.classList.toggle('scroll-bottom', !atBottom);
+  }
+
   function render(){
     const root = buildRoot();
     const list = $('#cart-lines-drawer', root);
@@ -239,6 +252,7 @@
     }
     // Let existing cart-ui.js update summary numbers if present
     if (typeof simpleCart !== 'undefined'){ try{ simpleCart.update(); }catch(_){ } }
+    updateScrollIndicators();
   }
 
   function open(trigger){
@@ -298,7 +312,7 @@
       document.addEventListener('product:addToCart', (e)=>open(e && e.target));
     },
     open: ()=>open(),
-    close
+    close: ()=>close()
   };
 
   // Auto-init after DOM ready


### PR DESCRIPTION
## Summary
- add fade indicators in cart drawer for scrollable content
- toggle overlay visibility on scroll so users know when more items exist

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static`
- `npm run test:spa` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c09e8d31a0832091cd0e75925ad05a