### PR TITLE
feat: show cart item count in drawer summary

### DIFF
--- a/assets/js/cart-drawer.js
+++ b/assets/js/cart-drawer.js
@@ -132,7 +132,7 @@
           <div class="cart-drawer-empty" hidden>Your cart is empty.</div>
         </div>
         <footer class="cart-drawer-footer">
-          <div class="row"><span>Subtotal</span><span id="summary-subtotal">—</span></div>
+          <div class="row"><span>Subtotal (<span id="summary-count">0 items</span>)</span><span id="summary-subtotal">—</span></div>
           <div class="cart-drawer-actions">
             <a class="btn btn-primary" href="${state.opts.checkoutUrl}">Checkout</a>
           </div>
@@ -152,6 +152,7 @@
     // Do not create duplicate summary ids on /cart page; hide footer subtotals there
     if (location.pathname.includes('/cart')){
       const sum = root.querySelector('#summary-subtotal'); if(sum){ sum.removeAttribute('id'); }
+      const cnt = root.querySelector('#summary-count'); if(cnt){ cnt.removeAttribute('id'); }
     }
 
     // Delegated controls for qty/remove (use same selectors as cart page)
@@ -235,6 +236,11 @@
     }else{
       empty.hidden = true;
       list.innerHTML = items.map(it=>cloneCartLine(it).outerHTML).join('');
+    }
+    const count = items.reduce((s, it) => s + (Number(it.qty) || 0), 0);
+    const countEl = $('#summary-count', root);
+    if (countEl) {
+      countEl.textContent = `${count} item${count === 1 ? '' : 's'}`;
     }
     // Let existing cart-ui.js update summary numbers if present
     if (typeof simpleCart !== 'undefined'){ try{ simpleCart.update(); }catch(_){ } }

--- a/assets/js/cart-ui.js
+++ b/assets/js/cart-ui.js
@@ -167,6 +167,11 @@
 
     // Summary numbers
     const el = (id)=>document.getElementById(id);
+    const countEl = el('summary-count');
+    if (countEl){
+      const count = items.reduce((s, it) => s + it.quantity(), 0);
+      countEl.textContent = `${count} item${count === 1 ? '' : 's'}`;
+    }
     el('summary-subtotal') && (el('summary-subtotal').textContent = fmt(totals.subtotal));
 
     if (totals.discount > 0){


### PR DESCRIPTION
## Summary
- display subtotal with item count in cart drawer footer
- update cart render logic to calculate and show item totals
- keep cart summary utilities aware of item count

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:static`


------
https://chatgpt.com/codex/tasks/task_e_68c09eca97a88320a35c4e74408082d3