### PR TITLE
fix: enable cart drawer close button

### DIFF
--- a/assets/js/cart-drawer.js
+++ b/assets/js/cart-drawer.js
@@ -145,7 +145,10 @@
 
     // Prevent clicks inside panel from bubbling to root/backdrop
     const _panel = root.querySelector('.cart-drawer-panel');
-    function panelClickStopper(e){ e.stopPropagation(); }
+    function panelClickStopper(e){
+      if (e.target.closest('[data-close]')) return;
+      e.stopPropagation();
+    }
     _panel && _panel.addEventListener('click', panelClickStopper);
 
 


### PR DESCRIPTION
## Summary
- allow cart drawer close button clicks to bubble so the drawer can close

## Testing
- `npm run lint:static`
- `npm run test:meta` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npm run test:sitemap` *(fails: Missing URLs: /c/hair-care/, /p/armoso-wow-bb-cream, ...)*
- `npm run test:features` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a05e7d348320bc8fb97bbc2bd2ae