### PR TITLE
Fix cart drawer close button

### DIFF
--- a/assets/css/cart-drawer.css
+++ b/assets/css/cart-drawer.css
@@ -1,5 +1,6 @@
 /* Cart Drawer styles (scoped to .cart-drawer*) */
 .cart-drawer-root{position:fixed;inset:0;pointer-events:none;z-index:1050;}
+.cart-drawer-root.open{pointer-events:auto;}
 .cart-drawer-backdrop{position:absolute;inset:0;background:rgba(0,0,0,.4);opacity:0;transition:opacity .18s ease;pointer-events:auto;}
 .cart-drawer-panel{position:absolute;right:0;top:0;height:100%;width:min(420px,100%);background:#fff;box-shadow:0 0 0 1px rgba(0,0,0,.05),0 24px 48px rgba(0,0,0,.24);transform:translate3d(100%,0,0);transition:transform .22s ease;display:flex;flex-direction:column;}
 .cart-drawer-root.open .cart-drawer-backdrop{opacity:1;}


### PR DESCRIPTION
## Summary
- allow pointer events on open cart drawer so close button works

## Testing
- `npm run lint:static`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a14f39d88320b9b83c03403cce41