### PR TITLE
Prevent background scroll while cart drawer is open

### DIFF
--- a/assets/js/cart-drawer.js
+++ b/assets/js/cart-drawer.js
@@ -295,6 +295,9 @@
     state.lastTrigger = trigger || document.activeElement;
     state.root.classList.add('open');
     state.root.removeAttribute('aria-hidden');
+    const sb = window.innerWidth - document.documentElement.clientWidth;
+    document.body.classList.add('drawer-open');
+    if(sb > 0) document.body.style.paddingRight = sb + 'px';
     render();
     const live = $('#cart-drawer-live'); if(live){ live.textContent='Added to your cart'; }
     // Focus first interactive element
@@ -318,6 +321,8 @@
     if (!state.root) return;
     state.root.classList.remove('open');
     state.root.setAttribute('aria-hidden','true');
+    document.body.classList.remove('drawer-open');
+    document.body.style.paddingRight = '';
     if (state.lastTrigger && typeof state.lastTrigger.focus === 'function') try{ state.lastTrigger.focus(); }catch(_){}
   }
 


### PR DESCRIPTION
## Summary
- Lock page scroll when the cart drawer opens to avoid accidental background swipes
- Restore scroll state when the drawer closes

## Testing
- `npm test` (fails: no test specified)
- `npm run lint:static`


------
https://chatgpt.com/codex/tasks/task_e_68c0a1ac40b08320aaa5f4e7e80b0a8e