### PR TITLE
fix: prevent cart drawer price overflow

### DIFF
--- a/assets/css/cart.css
+++ b/assets/css/cart.css
@@ -229,6 +229,9 @@ main.container{width:100%;max-width:1120px;margin:0 auto;padding:0 var(--space-4
 .cart-line .remove-link{ display:block; font-size:13px; color:var(--danger); margin-top:4px; }
 .cart-line .price{ font-weight:600; text-align:right; }
 
+/* Prevent middle column from stretching the drawer */
+.cart-line__info{ min-width:0; }
+
 /* Summary card readability */
 .summary-card .row{ margin:10px 0; }
 .summary-card .row span:last-child{ font-weight:600; }

--- a/assets/js/cart-drawer.js
+++ b/assets/js/cart-drawer.js
@@ -238,7 +238,7 @@
     const html = `
       <div class="cart-line">
         <div class="cart-line__img">${it.image ? `<img src="${it.image}" alt="">` : ''}</div>
-        <div>
+        <div class="cart-line__info">
           <p class="cart-line__title">${it.title||''}</p>
           <p class="cart-line__meta">${it.variantTitle||''}</p>
           <div class="cart-line__qty">


### PR DESCRIPTION
## Summary
- add `cart-line__info` wrapper to cart drawer items
- prevent middle column from stretching the cart drawer

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static`
- `npm run validate:data`


------
https://chatgpt.com/codex/tasks/task_e_68c0a37c125083208f6b9bbe55616f61