### PR TITLE
Remove cart item when decrementing quantity to zero

### DIFF
--- a/assets/js/cart-drawer.js
+++ b/assets/js/cart-drawer.js
@@ -226,8 +226,12 @@
     try{
       const items = state.api.getCartState().items;
       const found = items.find(i=>String(i.id)===String(id));
-      const next = Math.max(1, (found?.qty||1) + delta);
-      state.api.updateQty(id, next);
+      const next = (found?.qty||1) + delta;
+      if(next <= 0){
+        state.api.removeLineItem(id);
+      }else{
+        state.api.updateQty(id, next);
+      }
       render();
     }catch(_){}
   }


### PR DESCRIPTION
## Summary
- allow cart drawer quantity decrement to remove item when resulting quantity is zero

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static`


------
https://chatgpt.com/codex/tasks/task_e_68c0a3f734a88320b2abf5af68cac420