### PR TITLE
style: refresh cart drawer visuals

### DIFF
--- a/assets/css/cart-drawer.css
+++ b/assets/css/cart-drawer.css
@@ -6,7 +6,8 @@
 .cart-drawer-root.open .cart-drawer-panel{transform:translate3d(0,0,0);}
 
 .cart-drawer-header{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;border-bottom:1px solid #eee;}
-.cart-drawer-title{font-size:1.125rem;margin:0;}
+.cart-drawer-title{margin:0;font-weight:600;font-size:1.25rem;color:#111827;letter-spacing:-0.015em;}
+@media (min-width:768px){.cart-drawer-title{font-size:1.5rem;}}
 .cart-drawer-body{padding:12px 16px;overflow:auto;flex:1;contain:content;position:relative;}
 .cart-drawer-footer{border-top:1px solid #eee;padding:12px 16px;}
 
@@ -31,7 +32,11 @@
 
 /* Drawer footer layout: prevent overlap */
 .cart-drawer-footer .row{display:flex;justify-content:space-between;align-items:center;gap:8px;}
-.cart-drawer-footer #summary-subtotal{margin-left:auto;white-space:nowrap;}
+.cart-drawer-footer #summary-subtotal{margin-left:auto;white-space:nowrap;font-weight:600;font-size:1.5rem;color:#111827;}
+@media (min-width:768px){.cart-drawer-footer #summary-subtotal{font-size:1.875rem;}}
+.cart-drawer-footer .row>span:first-child{font-weight:500;font-size:.875rem;color:#111827;}
+.cart-drawer-footer .row>span:first-child .text-gray-600{color:#4b5563;}
+@media (min-width:768px){.cart-drawer-footer .row>span:first-child{font-size:1rem;}}
 
 /* Hide legacy toast if any slips through */
 .toast-notice{display:none !important;}

--- a/assets/css/cart.css
+++ b/assets/css/cart.css
@@ -255,3 +255,14 @@ main.container{width:100%;max-width:1120px;margin:0 auto;padding:0 var(--space-4
 
 .cart-summary .row{ justify-content:space-between; gap:12px; margin:8px 0; }
 .cart-summary .row.total{ font-weight:700; font-size:var(--font-size-500); }
+
+/* Cart Drawer visual updates */
+.cart-line__title.line-clamp-2{display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;overflow:hidden;}
+.cart-line__total{font-weight:600;color:#1E88E5;font-size:1.25rem;white-space:nowrap;}
+@media (min-width:768px){.cart-line__total{font-size:1.5rem;}}
+.cart-line__qty .btn{min-width:36px;width:36px;height:36px;padding:0;border-radius:9999px;box-shadow:none;}
+.cart-line__qty .btn:hover{background-color:#EFF6FF;}
+.cart-line__qty .btn-ghost{background:transparent;border:1px solid transparent;color:#ef4444;}
+.cart-line__qty .btn-ghost:hover{background-color:#fef2f2;}
+.cart-line__qty input[type="number"]{min-width:1.5ch;width:auto;text-align:center;font-size:1rem;font-weight:500;color:#111827;}
+.cart-line__qty .ml-auto{margin-left:auto;}

--- a/assets/js/cart-drawer.js
+++ b/assets/js/cart-drawer.js
@@ -124,7 +124,7 @@
       <div class="cart-drawer-backdrop" data-close tabindex="-1"></div>
       <div class="cart-drawer-panel" role="dialog" aria-modal="true" aria-labelledby="cart-drawer-title">
         <header class="cart-drawer-header">
-          <h2 id="cart-drawer-title" class="cart-drawer-title">Your cart</h2>
+          <h2 id="cart-drawer-title" class="cart-drawer-title font-semibold text-xl md:text-2xl tracking-tight text-gray-900">Your cart</h2>
           <button type="button" class="btn btn-link" data-close aria-label="Close cart">✕</button>
         </header>
         <div class="cart-drawer-body">
@@ -132,7 +132,10 @@
           <div class="cart-drawer-empty" hidden>Your cart is empty.</div>
         </div>
         <footer class="cart-drawer-footer">
-          <div class="row"><span>Subtotal (<span id="summary-count">0 items</span>)</span><span id="summary-subtotal">—</span></div>
+          <div class="row text-sm md:text-base font-medium">
+            <span class="text-gray-900">Subtotal <span class="text-gray-600">· <span id="summary-count">0 items</span></span></span>
+            <span id="summary-subtotal" class="text-gray-900 font-semibold text-2xl md:text-3xl">—</span>
+          </div>
           <div class="cart-drawer-actions">
             <a class="btn btn-primary" href="${state.opts.checkoutUrl}">Checkout</a>
           </div>
@@ -243,16 +246,16 @@
       <div class="cart-line">
         <div class="cart-line__img">${it.image ? `<img src="${it.image}" alt="">` : ''}</div>
         <div class="cart-line__info">
-          <p class="cart-line__title">${it.title||''}</p>
+          <p class="cart-line__title line-clamp-2">${it.title||''}</p>
           <p class="cart-line__meta">${it.variantTitle||''}</p>
           <div class="cart-line__qty">
-            <button class="btn btn-outline-secondary" data-dec="${it.id}">−</button>
-            <input type="number" min="1" value="${it.qty}" data-qty="${it.id}">
-            <button class="btn btn-outline-secondary" data-inc="${it.id}">+</button>
-            <button class="btn btn-link text-danger" data-del="${it.id}">Remove</button>
+            <button class="btn btn-outline-secondary h-9 w-9 rounded-full border hover:bg-blue-50 flex items-center justify-center" data-dec="${it.id}" aria-label="Decrease quantity"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/></svg></button>
+            <input type="number" min="1" value="${it.qty}" data-qty="${it.id}" class="min-w-[1.5ch] text-center text-base font-medium text-gray-900">
+            <button class="btn btn-outline-secondary h-9 w-9 rounded-full border hover:bg-blue-50 flex items-center justify-center" data-inc="${it.id}" aria-label="Increase quantity"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></button>
+            <button class="btn btn-ghost ml-auto h-9 w-9 text-red-500 hover:bg-red-50 flex items-center justify-center" data-del="${it.id}" aria-label="Remove item"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg></button>
           </div>
         </div>
-        <div class="cart-line__total">${typeof moneyPKR==='function' ? moneyPKR(total) : total}</div>
+        <div class="cart-line__total whitespace-nowrap text-[#1E88E5] font-semibold text-xl md:text-2xl">${typeof moneyPKR==='function' ? moneyPKR(total) : total}</div>
       </div>`;
     const t = document.createElement('template'); t.innerHTML = html.trim();
     return t.content.firstElementChild;


### PR DESCRIPTION
## Summary
- boost cart drawer title with stronger typography
- highlight item pricing, quantity controls, and delete action
- emphasize subtotal row with count and amount hierarchy

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:static`


------
https://chatgpt.com/codex/tasks/task_e_68c0a9e11cd08320a913c73fdadda31a