### PR TITLE
Align value props grid

### DIFF
--- a/index-old.html
+++ b/index-old.html
@@ -71,20 +71,20 @@
 
   <section class="value-props py-3 bg-light">
     <div class="container">
-      <div class="row text-center">
-        <div class="col-6 col-md-3 mb-3 mb-md-0">
+      <div class="row row-cols-2 row-cols-md-4 g-3 text-center justify-content-center">
+        <div class="col">
           <i class="fa-solid fa-certificate mb-2" aria-hidden="true"></i>
           <p class="mb-0">Authentic Products</p>
         </div>
-        <div class="col-6 col-md-3 mb-3 mb-md-0">
+        <div class="col">
           <i class="fa-solid fa-truck-fast mb-2" aria-hidden="true"></i>
           <p class="mb-0">Fast Shipping</p>
         </div>
-        <div class="col-6 col-md-3 mb-3 mb-md-0">
+        <div class="col">
           <i class="fa-solid fa-rotate-left mb-2" aria-hidden="true"></i>
           <p class="mb-0">Easy Returns</p>
         </div>
-        <div class="col-6 col-md-3">
+        <div class="col">
           <i class="fa-solid fa-lock mb-2" aria-hidden="true"></i>
           <p class="mb-0">Secure Payments</p>
         </div>

--- a/index.html
+++ b/index.html
@@ -53,20 +53,20 @@
     </section>
 
     <section class="container-narrow">
-      <div class="row text-center">
-        <div class="col-6 col-md-3 mb-3 mb-md-0">
+      <div class="row row-cols-2 row-cols-md-4 g-3 text-center justify-content-center">
+        <div class="col">
           <i class="fa-solid fa-certificate mb-2" aria-hidden="true"></i>
           <p class="mb-0">Authentic Products</p>
         </div>
-        <div class="col-6 col-md-3 mb-3 mb-md-0">
+        <div class="col">
           <i class="fa-solid fa-truck-fast mb-2" aria-hidden="true"></i>
           <p class="mb-0">Fast Shipping</p>
         </div>
-        <div class="col-6 col-md-3">
+        <div class="col">
           <i class="fa-solid fa-hand-holding-dollar mb-2" aria-hidden="true"></i>
           <p class="mb-0">Cash on Delivery</p>
         </div>
-        <div class="col-6 col-md-3">
+        <div class="col">
           <i class="fa-solid fa-tags mb-2" aria-hidden="true"></i>
           <p class="mb-0">Best Prices</p>
         </div>


### PR DESCRIPTION
## Summary
- center value proposition icons with Bootstrap grid gap for even spacing
- update legacy home page to match grid spacing

## Testing
- `npm run lint:static`
- `npm run validate:data`
- `npm run test:meta` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npm run test:sitemap` *(fails: Missing URLs: /c/hair-care/, ...)*
- `npm run test:spa` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npm run test:lighthouse` *(fails: connect ECONNREFUSED 127.0.0.1:35633)*
- `npm run test:features` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a66be65c8320a08a77eb47de1fcd