### PR TITLE
style: refine cart drawer subtotal and pricing layout

### DIFF
--- a/assets/css/cart-drawer.css
+++ b/assets/css/cart-drawer.css
@@ -8,11 +8,11 @@
 .cart-drawer-header{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;border-bottom:1px solid #eee;}
 .cart-drawer-title{font-size:1.125rem;margin:0;}
 .cart-drawer-body{padding:12px 16px;overflow:auto;flex:1;contain:content;position:relative;}
-.cart-drawer-footer{border-top:1px solid #eee;padding:12px 16px;}
+
 
 .cart-drawer-empty{padding:24px 8px;color:#666;text-align:center;}
 
-.cart-drawer-actions{display:flex;gap:8px;margin-top:12px;}
+.cart-drawer-actions{display:flex;gap:8px;}
 .cart-drawer-actions .btn{flex:1;}
 
 @media (max-width:768px){
@@ -29,9 +29,7 @@
 .cart-drawer-root.open .cart-drawer-backdrop{pointer-events:auto;}
 .cart-drawer-root:not(.open) .cart-drawer-panel{pointer-events:none;}
 
-/* Drawer footer layout: prevent overlap */
-.cart-drawer-footer .row{display:flex;justify-content:space-between;align-items:center;gap:8px;}
-.cart-drawer-footer #summary-subtotal{margin-left:auto;white-space:nowrap;}
+/* Drawer footer layout: handled by utility classes */
 
 /* Hide legacy toast if any slips through */
 .toast-notice{display:none !important;}

--- a/assets/js/cart-drawer.js
+++ b/assets/js/cart-drawer.js
@@ -131,10 +131,13 @@
           <div id="cart-lines-drawer"></div>
           <div class="cart-drawer-empty" hidden>Your cart is empty.</div>
         </div>
-        <footer class="cart-drawer-footer">
-          <div class="row"><span>Subtotal (<span id="summary-count">0 items</span>)</span><span id="summary-subtotal">—</span></div>
+        <footer class="cart-drawer-footer p-4 border-t bg-gray-50 space-y-3">
+          <div class="row flex justify-between">
+            <span class="text-gray-900 text-sm md:text-base font-medium">Subtotal · <span id="summary-count" class="text-gray-500 font-normal">0 items</span></span>
+            <span id="summary-subtotal" class="text-gray-900 font-semibold text-2xl md:text-3xl whitespace-nowrap">—</span>
+          </div>
           <div class="cart-drawer-actions">
-            <a class="btn btn-primary" href="${state.opts.checkoutUrl}">Checkout</a>
+            <a class="w-full rounded-xl h-12 text-base font-semibold bg-[#1E88E5] text-white hover:brightness-95" href="${state.opts.checkoutUrl}">Checkout</a>
           </div>
         </footer>
       </div>
@@ -252,7 +255,7 @@
             <button class="btn btn-link text-danger" data-del="${it.id}">Remove</button>
           </div>
         </div>
-        <div class="cart-line__total">${typeof moneyPKR==='function' ? moneyPKR(total) : total}</div>
+        <div class="cart-line__total text-xl md:text-2xl">${typeof moneyPKR==='function' ? moneyPKR(total) : total}</div>
       </div>`;
     const t = document.createElement('template'); t.innerHTML = html.trim();
     return t.content.firstElementChild;


### PR DESCRIPTION
## Summary
- restyle cart drawer footer with responsive subtotal, item count, and checkout button
- enlarge line-item totals and subtotal amounts for better readability
- drop legacy footer CSS in favor of utility classes

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:static`


------
https://chatgpt.com/codex/tasks/task_e_68c0aef45110832090fdae545647fa78