### PR TITLE
Refactor cart line markup

### DIFF
--- a/assets/js/cart-drawer.js
+++ b/assets/js/cart-drawer.js
@@ -243,19 +243,33 @@
     // IMPORTANT: Keep structure identical to cart-ui.js
     const total = (Number(it.price)||0) * (Number(it.qty)||0);
     const html = `
-      <div class="cart-line">
+      <div class="cart-line flex items-center gap-4 p-3 rounded-2xl shadow-sm bg-white">
         <div class="cart-line__img">${it.image ? `<img src="${it.image}" alt="">` : ''}</div>
-        <div class="cart-line__info">
-          <p class="cart-line__title">${it.title||''}</p>
+
+        <div class="cart-line__info flex-1 min-w-0">
+          <div class="flex justify-between items-start gap-2">
+            <p class="text-gray-900 font-semibold text-sm md:text-base leading-snug line-clamp-2 flex-1">${it.title||''}</p>
+            <p class="text-[#1E88E5] font-semibold text-xl md:text-2xl whitespace-nowrap">${typeof moneyPKR==='function' ? moneyPKR(total) : total}</p>
+          </div>
+
           <p class="cart-line__meta">${it.variantTitle||''}</p>
-          <div class="cart-line__qty">
-            <button class="btn btn-outline-secondary" data-dec="${it.id}">−</button>
-            <input type="number" min="1" value="${it.qty}" data-qty="${it.id}">
-            <button class="btn btn-outline-secondary" data-inc="${it.id}">+</button>
-            <button class="btn btn-link text-danger" data-del="${it.id}">Remove</button>
+
+          <div class="cart-line__qty flex items-center gap-3 mt-3">
+            <button type="button" class="h-9 w-9 rounded-full border border-gray-200 bg-white text-gray-700 inline-flex items-center justify-center hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-200" data-dec="${it.id}" aria-label="Decrease quantity">
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="pointer-events-none"><path d="M5 12h14"/></svg>
+            </button>
+
+            <span class="text-gray-900 text-base font-medium inline-block text-center min-w-[1.5ch]" data-qty="${it.id}">${it.qty}</span>
+
+            <button type="button" class="h-9 w-9 rounded-full border border-gray-200 bg-white text-gray-700 inline-flex items-center justify-center hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-200" data-inc="${it.id}" aria-label="Increase quantity">
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="pointer-events-none"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
+            </button>
+
+            <button type="button" class="ml-auto h-9 w-9 rounded-full inline-flex items-center justify-center text-red-500 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-200" data-del="${it.id}" aria-label="Remove item">
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="pointer-events-none"><path d="M3 6h18"/><path d="M8 6v-2c0-1.1.9-2 2-2h4c1.1 0 2 .9 2 2v2"/><path d="M19 6l-1 14c0 1.1-.9 2-2 2H8c-1.1 0-2-.9-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg>
+            </button>
           </div>
         </div>
-        <div class="cart-line__total">${typeof moneyPKR==='function' ? moneyPKR(total) : total}</div>
       </div>`;
     const t = document.createElement('template'); t.innerHTML = html.trim();
     return t.content.firstElementChild;

--- a/assets/js/cart-ui.js
+++ b/assets/js/cart-ui.js
@@ -147,19 +147,33 @@
           const price = Number(it.get('price')||0);
           const total = qty * price;
           return `
-            <div class="cart-line">
+            <div class="cart-line flex items-center gap-4 p-3 rounded-2xl shadow-sm bg-white">
               <div class="cart-line__img">${img? `<img src="${img}" alt="">` : ''}</div>
-              <div>
-                <p class="cart-line__title">${title}</p>
+
+              <div class="cart-line__info flex-1 min-w-0">
+                <div class="flex justify-between items-start gap-2">
+                  <p class="text-gray-900 font-semibold text-sm md:text-base leading-snug line-clamp-2 flex-1">${title}</p>
+                  <p class="text-[#1E88E5] font-semibold text-xl md:text-2xl whitespace-nowrap">${fmt(total)}</p>
+                </div>
+
                 <p class="cart-line__meta">${it.get('variant')||''}</p>
-                <div class="cart-line__qty">
-                  <button class="btn btn-outline-secondary" data-dec="${it.id()}">−</button>
-                  <input type="number" min="1" value="${qty}" data-qty="${it.id()}">
-                  <button class="btn btn-outline-secondary" data-inc="${it.id()}">+</button>
-                  <button class="btn btn-link text-danger" data-del="${it.id()}">Remove</button>
+
+                <div class="cart-line__qty flex items-center gap-3 mt-3">
+                  <button type="button" class="h-9 w-9 rounded-full border border-gray-200 bg-white text-gray-700 inline-flex items-center justify-center hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-200" data-dec="${it.id()}" aria-label="Decrease quantity">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="pointer-events-none"><path d="M5 12h14"/></svg>
+                  </button>
+
+                  <span class="text-gray-900 text-base font-medium inline-block text-center min-w-[1.5ch]" data-qty="${it.id()}">${qty}</span>
+
+                  <button type="button" class="h-9 w-9 rounded-full border border-gray-200 bg-white text-gray-700 inline-flex items-center justify-center hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-200" data-inc="${it.id()}" aria-label="Increase quantity">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="pointer-events-none"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
+                  </button>
+
+                  <button type="button" class="ml-auto h-9 w-9 rounded-full inline-flex items-center justify-center text-red-500 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-200" data-del="${it.id()}" aria-label="Remove item">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="pointer-events-none"><path d="M3 6h18"/><path d="M8 6v-2c0-1.1.9-2 2-2h4c1.1 0 2 .9 2 2v2"/><path d="M19 6l-1 14c0 1.1-.9 2-2 2H8c-1.1 0-2-.9-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg>
+                  </button>
                 </div>
               </div>
-              <div class="cart-line__total">${fmt(total)}</div>
             </div>`;
         }).join('');
       }


### PR DESCRIPTION
## Summary
- update cart item template to flex layout with blue price, round quantity controls, and icon delete
- mirror new template in cart drawer clone function

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint:static`


------
https://chatgpt.com/codex/tasks/task_e_68c1208287448320960094264e772e4b