### PR TITLE
Ensure cart drawer opens after add to cart

### DIFF
--- a/assets/js/cart-drawer.js
+++ b/assets/js/cart-drawer.js
@@ -93,7 +93,8 @@
     opts: { checkoutUrl:'/cart.html' },
     root: null,
     lastTrigger: null,
-    autoCloseTimer: null
+    autoCloseTimer: null,
+    simpleCartBound: false
   };
 
   function injectCssOnce(){
@@ -113,6 +114,23 @@
     link.href = href;
     link.dataset.cartDrawer = '1';
     document.head.appendChild(link);
+  }
+
+  function bindSimpleCart(){
+    if (state.simpleCartBound) return;
+    if (typeof simpleCart === 'undefined' || typeof simpleCart.bind !== 'function') return;
+    try{
+      simpleCart.bind('afterAdd', function(){
+        try{
+          if(state.root && state.root.classList.contains('open')){
+            render();
+          }else{
+            open();
+          }
+        }catch(_){}
+      });
+      state.simpleCartBound = true;
+    }catch(_){}
   }
 
   function buildRoot(){
@@ -294,6 +312,7 @@
   }
 
   function open(trigger){
+    bindSimpleCart();
     injectCssOnce();
       disableToasts();
     injectCartCss();
@@ -353,6 +372,7 @@
       ensureCartUi(function(){ try{ if(typeof simpleCart!=='undefined'){ simpleCart.update(); } }catch(_){ } });
       // Listen for add-to-cart events
       document.addEventListener('product:addToCart', (e)=>open(e && e.target));
+      bindSimpleCart();
     },
     open: ()=>open(),
     close: ()=>close()

--- a/assets/js/pdp-hydrate.js
+++ b/assets/js/pdp-hydrate.js
@@ -163,7 +163,11 @@
             simpleCart.add({ id: p.id || p.slug, name: p.name, price: p.price.current, quantity: 1, image: (p.images && p.images[0]) || '' });
           }
         }catch(e){ console.warn('cart error', e); }
-        document.dispatchEvent(new CustomEvent('product:addToCart',{detail:{id:p.id||p.slug,qty:1}}));
+        var detail = { qty: 1, skipSimpleCart: true };
+        var pid = p.id || p.slug;
+        if(pid) detail.id = pid;
+        var evt = new CustomEvent('product:addToCart',{ detail: detail, bubbles:true });
+        btn.dispatchEvent(evt);
         if(typeof showAddedToast === 'function') showAddedToast(p.name);
       });
     });

--- a/assets/js/pdp.js
+++ b/assets/js/pdp.js
@@ -45,7 +45,8 @@
   }
 
   // ATC buttons
-  function addToCart(qty){
+  function addToCart(qty, trigger){
+    const quantity = qty || 1;
     try{
       if(typeof simpleCart !== 'undefined'){
         simpleCart.add({
@@ -53,11 +54,15 @@
           name: product.name || product.title,
           price: product.price?.current ?? product.price,
           image: (product.images && product.images[0]) || product.image || '',
-          quantity: qty||1
+          quantity: quantity
         });
       }
     }catch(e){ console.warn('cart error', e); }
-    document.dispatchEvent(new CustomEvent('product:addToCart', { detail:{ id: product.id || product.slug, qty: qty||1 }}));
+    const detail = { qty: quantity, skipSimpleCart: true };
+    const pid = product.id || product.slug;
+    if(pid) detail.id = pid;
+    const evt = new CustomEvent('product:addToCart', { detail, bubbles: true });
+    (trigger || document).dispatchEvent(evt);
     if(typeof showAddedToast === 'function') showAddedToast(product.name || product.title);
   }
   const atcButtons = document.querySelectorAll('[data-atc]');
@@ -72,7 +77,7 @@
     });
   }else{
     atcButtons.forEach(btn=>{
-      btn.addEventListener('click', ()=> addToCart(1));
+      btn.addEventListener('click', ()=> addToCart(1, btn));
     });
   }
 

--- a/assets/js/product-card.js
+++ b/assets/js/product-card.js
@@ -159,12 +159,14 @@
   });
 
   document.addEventListener('product:addToCart', (e)=>{
-    const id = e.detail && e.detail.id;
-    const qty = (e.detail && e.detail.qty) || 1;
+    const detail = e.detail || {};
+    const id = detail.id;
+    const qty = Number(detail.qty) || 1;
+    const skipSimpleCart = !!detail.skipSimpleCart;
     const item = ITEM_CACHE[id];
     if(!item) return;
     try{
-      if(typeof simpleCart !== 'undefined'){
+      if(!skipSimpleCart && typeof simpleCart !== 'undefined'){
         simpleCart.add({
           id: id,
           name: item.title,
@@ -174,7 +176,7 @@
         });
       }
     }catch(err){ console.warn('cart error', err); }
-    showAddedToast(item.title);
+    if(!skipSimpleCart) showAddedToast(item.title);
   });
 
   function showAddedToast(name){

--- a/assets/js/product-page.js
+++ b/assets/js/product-page.js
@@ -188,6 +188,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       addBtn.addEventListener('click', () => {
         const qty = parseInt(qtyEl.value,10) || 1;
         const item = currentVariant ? {...product, ...currentVariant} : product;
+        const detail = { qty, skipSimpleCart: true };
+        const pid = item.id || item.slug || product.id || product.slug;
+        if (pid) detail.id = pid;
+        const evt = new CustomEvent('product:addToCart', { detail, bubbles: true });
+        addBtn.dispatchEvent(evt);
         Analytics.addToCart(item, qty);
         if (liveRegion) liveRegion.textContent = 'Added to cart';
         showAddedToast(item.name);

--- a/assets/js/ui-cards.js
+++ b/assets/js/ui-cards.js
@@ -115,6 +115,11 @@ export function buildProductCard(prod) {
   if (!disabled) {
     const btn = wrap.querySelector('.item_add');
     btn.addEventListener('click', () => {
+      const detail = { qty: 1, skipSimpleCart: true };
+      const id = prod.id || prod.slug;
+      if (id) detail.id = id;
+      const evt = new CustomEvent('product:addToCart', { detail, bubbles: true });
+      btn.dispatchEvent(evt);
       Analytics.addToCart(prod, 1);
       showAddedToast(prod.name);
     });
@@ -147,19 +152,22 @@ buildProductCard = function(prod){
 
   // cart and analytics on add to cart
   const priceNum = normalizePrice(prod.price);
-  el.addEventListener('product:addToCart', () => {
+  el.addEventListener('product:addToCart', (evt) => {
+    const detail = evt?.detail || {};
+    const qty = Number(detail.qty) || 1;
+    const skipSimpleCart = !!detail.skipSimpleCart;
     try{
-      if(typeof simpleCart !== 'undefined' && priceNum !== null){
+      if(!skipSimpleCart && typeof simpleCart !== 'undefined' && priceNum !== null){
         simpleCart.add({
           id: prod.id || prod.slug,
           name: prod.name,
           price: priceNum,
           image: (prod.images && prod.images[0]) || prod.image || '',
-          quantity: 1
+          quantity: qty
         });
       }
     }catch(e){ console.warn('cart error', e); }
-    Analytics.addToCart(prod, 1);
+    Analytics.addToCart(prod, qty);
     showAddedToast(prod.name);
   });
   return el;


### PR DESCRIPTION
## Summary
- dispatch the `product:addToCart` event from legacy add-to-cart buttons and PDP flows with metadata to avoid double adds
- update product card handlers to honour the new skip flag and reuse the requested quantity for analytics
- bind the cart drawer to simpleCart's `afterAdd` hook so it opens even when only the cart API fires

## Testing
- `npm run lint:static`
- `npm run test:features` *(fails: missing system dependency libatk-1.0.so.0 when launching Puppeteer)*

------
https://chatgpt.com/codex/tasks/task_e_68c868511d48832090f5f1d30cb41530