### PR TITLE
Ensure cart drawer opens from PDP flows

### DIFF
--- a/assets/js/cart-drawer.js
+++ b/assets/js/cart-drawer.js
@@ -78,7 +78,11 @@
   
   // Kill legacy toast notifications everywhere (replace with drawer UX)
   function disableToasts(){
-    try{ window.showAddedToast = function(){}; }catch(_){}
+    try{
+      window.showAddedToast = function(){
+        try{ CartDrawer.open(); }catch(_){ }
+      };
+    }catch(_){ }
     try{
       // Remove any existing toast DOM and block future ones
       const cleanup = ()=>document.querySelectorAll('.toast-notice').forEach(n=>n.remove());
@@ -93,7 +97,9 @@
     opts: { checkoutUrl:'/cart.html' },
     root: null,
     lastTrigger: null,
-    autoCloseTimer: null
+    autoCloseTimer: null,
+    simpleCartBound: false,
+    initialized: false
   };
 
   function injectCssOnce(){
@@ -113,6 +119,52 @@
     link.href = href;
     link.dataset.cartDrawer = '1';
     document.head.appendChild(link);
+  }
+
+  function bindSimpleCart(){
+    if (state.simpleCartBound) return;
+    if (typeof simpleCart === 'undefined' || typeof simpleCart.bind !== 'function') return;
+    try{
+      simpleCart.bind('afterAdd', function(){
+        try{
+          if(state.root && state.root.classList.contains('open')){
+            render();
+          }else{
+            open();
+          }
+        }catch(_){}
+      });
+      state.simpleCartBound = true;
+    }catch(_){}
+  }
+
+  function ensureReady(opts){
+    if (opts && typeof opts === 'object'){
+      state.opts = Object.assign(state.opts, opts);
+      if (opts.getCartState || opts.updateQty || opts.removeLineItem){
+        state.api = Object.assign({}, defaultApi, {
+          getCartState: opts.getCartState || defaultApi.getCartState,
+          updateQty: opts.updateQty || defaultApi.updateQty,
+          removeLineItem: opts.removeLineItem || defaultApi.removeLineItem
+        });
+      }
+    }
+    if (location.pathname.includes('/cart')) return false;
+    injectCssOnce();
+    disableToasts();
+    injectCartCss();
+    buildRoot();
+    if (state.root){
+      const checkout = state.root.querySelector('.cart-drawer-actions a[href]');
+      if (checkout){
+        const href = state.opts?.checkoutUrl || '/cart.html';
+        checkout.setAttribute('href', href);
+      }
+    }
+    ensureCartUi(function(){ try{ if(typeof simpleCart!=='undefined'){ simpleCart.update(); } }catch(_){ } });
+    bindSimpleCart();
+    state.initialized = true;
+    return true;
   }
 
   function buildRoot(){
@@ -294,11 +346,7 @@
   }
 
   function open(trigger){
-    injectCssOnce();
-      disableToasts();
-    injectCartCss();
-    buildRoot();
-    ensureCartUi(function(){ try{ if(typeof simpleCart!=='undefined'){ simpleCart.update(); } }catch(_){ } });
+    if (!ensureReady()) return;
     state.lastTrigger = trigger || document.activeElement;
     state.root.classList.add('open');
     state.root.removeAttribute('aria-hidden');
@@ -336,28 +384,35 @@
   // Global
   window.CartDrawer = {
     init(opts={}){
-      // Skip on cart page to avoid duplicate summary IDs
-      if (location.pathname.includes('/cart')) return;
-      state.opts = Object.assign(state.opts, opts);
-      if (opts.getCartState || opts.updateQty || opts.removeLineItem){
-        state.api = Object.assign({}, defaultApi, {
-          getCartState: opts.getCartState || defaultApi.getCartState,
-          updateQty: opts.updateQty || defaultApi.updateQty,
-          removeLineItem: opts.removeLineItem || defaultApi.removeLineItem
-        });
-      }
-      injectCssOnce();
-      disableToasts();
-      injectCartCss();
-      buildRoot();
-      ensureCartUi(function(){ try{ if(typeof simpleCart!=='undefined'){ simpleCart.update(); } }catch(_){ } });
-      // Listen for add-to-cart events
-      document.addEventListener('product:addToCart', (e)=>open(e && e.target));
+      ensureReady(opts);
     },
-    open: ()=>open(),
+    open(trigger){
+      open(trigger);
+    },
     close: ()=>close()
   };
 
-  // Auto-init after DOM ready
-  document.addEventListener('DOMContentLoaded', ()=>{ window.CartDrawer && window.CartDrawer.init(); disableToasts(); });
+  // Always react to add-to-cart events, even if init hasn't run yet
+  document.addEventListener('product:addToCart', (e)=>open(e && e.target));
+
+  function autoInit(){
+    if (window.CartDrawer){ window.CartDrawer.init(); }
+    disableToasts();
+    try{
+      const pending = window.__CART_DRAWER_WANTS_OPEN__;
+      if(pending){
+        window.__CART_DRAWER_WANTS_OPEN__ = null;
+        const trigger = pending && pending.trigger && typeof pending.trigger.focus === 'function'
+          ? pending.trigger
+          : null;
+        CartDrawer.open(trigger);
+      }
+    }catch(_){ }
+  }
+
+  if (document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', autoInit);
+  }else{
+    autoInit();
+  }
 })();

--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -49,3 +49,39 @@ $(function() {
     }, 400);
   });
 });
+
+(function ensureCartDrawerScript(){
+  function resolveCartDrawerSrc(){
+    try {
+      var current = Array.prototype.slice.call(document.scripts || [])
+        .find(function(scr){ return scr && scr.src && scr.src.indexOf('config.js') !== -1; });
+      if (current){
+        var raw = current.getAttribute('src');
+        if (raw){
+          var replaced = raw.replace(/config\.js(?:\?.*)?$/,'cart-drawer.js');
+          if (replaced !== raw) return replaced;
+        }
+        var url = new URL(current.src, window.location.href);
+        return url.origin + url.pathname.replace(/config\.js$/, 'cart-drawer.js');
+      }
+    }catch(_){ }
+    return '/assets/js/cart-drawer.js';
+  }
+
+  function loadCartDrawer(){
+    if (window.CartDrawer || window.__CART_DRAWER_LOADING__) return;
+    window.__CART_DRAWER_LOADING__ = true;
+    var script = document.createElement('script');
+    script.src = resolveCartDrawerSrc();
+    script.async = true;
+    script.dataset.cartDrawerAutoload = '1';
+    script.onload = script.onerror = function(){ window.__CART_DRAWER_LOADING__ = false; };
+    (document.head || document.documentElement || document.body).appendChild(script);
+  }
+
+  if (document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', loadCartDrawer, { once: true });
+  }else{
+    loadCartDrawer();
+  }
+})();

--- a/assets/js/pdp-hydrate.js
+++ b/assets/js/pdp-hydrate.js
@@ -163,7 +163,11 @@
             simpleCart.add({ id: p.id || p.slug, name: p.name, price: p.price.current, quantity: 1, image: (p.images && p.images[0]) || '' });
           }
         }catch(e){ console.warn('cart error', e); }
-        document.dispatchEvent(new CustomEvent('product:addToCart',{detail:{id:p.id||p.slug,qty:1}}));
+        var detail = { qty: 1, skipSimpleCart: true };
+        var pid = p.id || p.slug;
+        if(pid) detail.id = pid;
+        var evt = new CustomEvent('product:addToCart',{ detail: detail, bubbles:true });
+        btn.dispatchEvent(evt);
         if(typeof showAddedToast === 'function') showAddedToast(p.name);
       });
     });

--- a/assets/js/pdp.js
+++ b/assets/js/pdp.js
@@ -45,7 +45,8 @@
   }
 
   // ATC buttons
-  function addToCart(qty){
+  function addToCart(qty, trigger){
+    const quantity = qty || 1;
     try{
       if(typeof simpleCart !== 'undefined'){
         simpleCart.add({
@@ -53,11 +54,15 @@
           name: product.name || product.title,
           price: product.price?.current ?? product.price,
           image: (product.images && product.images[0]) || product.image || '',
-          quantity: qty||1
+          quantity: quantity
         });
       }
     }catch(e){ console.warn('cart error', e); }
-    document.dispatchEvent(new CustomEvent('product:addToCart', { detail:{ id: product.id || product.slug, qty: qty||1 }}));
+    const detail = { qty: quantity, skipSimpleCart: true };
+    const pid = product.id || product.slug;
+    if(pid) detail.id = pid;
+    const evt = new CustomEvent('product:addToCart', { detail, bubbles: true });
+    (trigger || document).dispatchEvent(evt);
     if(typeof showAddedToast === 'function') showAddedToast(product.name || product.title);
   }
   const atcButtons = document.querySelectorAll('[data-atc]');
@@ -72,7 +77,7 @@
     });
   }else{
     atcButtons.forEach(btn=>{
-      btn.addEventListener('click', ()=> addToCart(1));
+      btn.addEventListener('click', ()=> addToCart(1, btn));
     });
   }
 

--- a/assets/js/product-card.js
+++ b/assets/js/product-card.js
@@ -159,12 +159,14 @@
   });
 
   document.addEventListener('product:addToCart', (e)=>{
-    const id = e.detail && e.detail.id;
-    const qty = (e.detail && e.detail.qty) || 1;
+    const detail = e.detail || {};
+    const id = detail.id;
+    const qty = Number(detail.qty) || 1;
+    const skipSimpleCart = !!detail.skipSimpleCart;
     const item = ITEM_CACHE[id];
     if(!item) return;
     try{
-      if(typeof simpleCart !== 'undefined'){
+      if(!skipSimpleCart && typeof simpleCart !== 'undefined'){
         simpleCart.add({
           id: id,
           name: item.title,
@@ -174,10 +176,22 @@
         });
       }
     }catch(err){ console.warn('cart error', err); }
-    showAddedToast(item.title);
+    if(!skipSimpleCart) showAddedToast(item.title);
   });
 
   function showAddedToast(name){
+    var trigger = document.activeElement;
+    try{
+      if(window.CartDrawer && typeof window.CartDrawer.open === 'function'){
+        window.CartDrawer.open(trigger);
+        return;
+      }
+    }catch(_){ }
+    try{
+      window.__CART_DRAWER_WANTS_OPEN__ = {
+        trigger: trigger && typeof trigger.focus === 'function' ? trigger : null
+      };
+    }catch(_){ }
     const toast = document.createElement('div');
     toast.className = 'toast-notice position-fixed bottom-0 end-0 m-3 p-2 bg-dark text-white rounded';
     toast.style.zIndex = '1055';

--- a/assets/js/product-page.js
+++ b/assets/js/product-page.js
@@ -188,6 +188,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       addBtn.addEventListener('click', () => {
         const qty = parseInt(qtyEl.value,10) || 1;
         const item = currentVariant ? {...product, ...currentVariant} : product;
+        const detail = { qty, skipSimpleCart: true };
+        const pid = item.id || item.slug || product.id || product.slug;
+        if (pid) detail.id = pid;
+        const evt = new CustomEvent('product:addToCart', { detail, bubbles: true });
+        addBtn.dispatchEvent(evt);
         Analytics.addToCart(item, qty);
         if (liveRegion) liveRegion.textContent = 'Added to cart';
         showAddedToast(item.name);

--- a/assets/js/ui-cards.js
+++ b/assets/js/ui-cards.js
@@ -43,6 +43,18 @@ export const Analytics = {
 
 // toast helper
 export function showAddedToast(name) {
+  const trigger = document.activeElement;
+  try {
+    if (window.CartDrawer && typeof window.CartDrawer.open === 'function') {
+      window.CartDrawer.open(trigger);
+      return;
+    }
+  } catch (_) {}
+  try {
+    window.__CART_DRAWER_WANTS_OPEN__ = {
+      trigger: trigger && typeof trigger.focus === 'function' ? trigger : null
+    };
+  } catch (_) {}
   const toast = document.createElement('div');
   toast.className = 'toast-notice position-fixed bottom-0 end-0 m-3 p-2 bg-dark text-white rounded';
   toast.style.zIndex = '1055';
@@ -115,6 +127,11 @@ export function buildProductCard(prod) {
   if (!disabled) {
     const btn = wrap.querySelector('.item_add');
     btn.addEventListener('click', () => {
+      const detail = { qty: 1, skipSimpleCart: true };
+      const id = prod.id || prod.slug;
+      if (id) detail.id = id;
+      const evt = new CustomEvent('product:addToCart', { detail, bubbles: true });
+      btn.dispatchEvent(evt);
       Analytics.addToCart(prod, 1);
       showAddedToast(prod.name);
     });
@@ -147,19 +164,22 @@ buildProductCard = function(prod){
 
   // cart and analytics on add to cart
   const priceNum = normalizePrice(prod.price);
-  el.addEventListener('product:addToCart', () => {
+  el.addEventListener('product:addToCart', (evt) => {
+    const detail = evt?.detail || {};
+    const qty = Number(detail.qty) || 1;
+    const skipSimpleCart = !!detail.skipSimpleCart;
     try{
-      if(typeof simpleCart !== 'undefined' && priceNum !== null){
+      if(!skipSimpleCart && typeof simpleCart !== 'undefined' && priceNum !== null){
         simpleCart.add({
           id: prod.id || prod.slug,
           name: prod.name,
           price: priceNum,
           image: (prod.images && prod.images[0]) || prod.image || '',
-          quantity: 1
+          quantity: qty
         });
       }
     }catch(e){ console.warn('cart error', e); }
-    Analytics.addToCart(prod, 1);
+    Analytics.addToCart(prod, qty);
     showAddedToast(prod.name);
   });
   return el;


### PR DESCRIPTION
## Summary
- allow CartDrawer.open to accept an optional trigger and honor any pending open requests once the drawer auto-initializes
- route all showAddedToast helpers through CartDrawer so PDP and card flows queue the drawer if it is not ready instead of showing only a toast

## Testing
- `npm run lint:static`


------
https://chatgpt.com/codex/tasks/task_e_68c868511d48832090f5f1d30cb41530