### PR TITLE
Fix cart drawer readiness on add to cart

### DIFF
--- a/assets/js/cart-drawer.js
+++ b/assets/js/cart-drawer.js
@@ -149,13 +149,13 @@
         });
       }
     }
-    if (location.pathname.includes('/cart')) return false;
     injectCssOnce();
     disableToasts();
     injectCartCss();
-    buildRoot();
-    if (state.root){
-      const checkout = state.root.querySelector('.cart-drawer-actions a[href]');
+    const root = buildRoot();
+    if (!root) return false;
+    if (root){
+      const checkout = root.querySelector('.cart-drawer-actions a[href]');
       if (checkout){
         const href = state.opts?.checkoutUrl || '/cart.html';
         checkout.setAttribute('href', href);


### PR DESCRIPTION
## Summary
- ensure the cart drawer always builds by removing the URL guard that prevented initialization
- guard checkout link wiring behind the built drawer element while keeping initialization logic intact

## Testing
- npm run lint:static

------
https://chatgpt.com/codex/tasks/task_e_68d124cede148320afca3b8fffe4b2bd