### PR TITLE
Ensure cart drawer waits for CSS paint before opening

### DIFF
--- a/assets/js/cart-drawer.js
+++ b/assets/js/cart-drawer.js
@@ -6,6 +6,22 @@
   const $ = (sel, ctx=document)=>ctx.querySelector(sel);
   const $$ = (sel, ctx=document)=>Array.from(ctx.querySelectorAll(sel));
 
+  function waitForFrames(count=2){
+    return new Promise((resolve)=>{
+      const raf = typeof window.requestAnimationFrame === 'function'
+        ? window.requestAnimationFrame.bind(window)
+        : (cb)=>setTimeout(cb, 16);
+      const step = ()=>{
+        if (--count <= 0){
+          resolve();
+        }else{
+          raf(step);
+        }
+      };
+      raf(step);
+    });
+  }
+
   // Cart API bridge (can be overridden via init)
   const defaultApi = {
     getCartState(){
@@ -99,12 +115,79 @@
     lastTrigger: null,
     autoCloseTimer: null,
     simpleCartBound: false,
-    initialized: false
+    initialized: false,
+    cssReady: true,
+    cssPromise: null,
+    cssPromiseHandlerAttached: false,
+    awaitingCssForOpen: false,
+    pendingOpenTrigger: null,
+    cssReadyConfirmed: false
   };
+
+  function waitForStylesheet(link){
+    if (!link) return Promise.resolve();
+    return new Promise((resolve)=>{
+      let done = false;
+      let timer = null;
+      const cleanup = ()=>{
+        link.removeEventListener('load', finish);
+        link.removeEventListener('error', finish);
+        if (timer){ clearTimeout(timer); timer = null; }
+      };
+      const finish = ()=>{
+        if (done) return;
+        done = true;
+        cleanup();
+        resolve();
+      };
+      const scheduleCheck = ()=>{
+        if (done) return;
+        if (timer){ clearTimeout(timer); }
+        timer = setTimeout(check, 30);
+      };
+      const sheetReady = ()=>{
+        const sheet = link.sheet;
+        if (!sheet) return false;
+        try{
+          if ('cssRules' in sheet){ void sheet.cssRules; return true; }
+        }catch(err){ }
+        try{
+          if ('rules' in sheet){ void sheet.rules; return true; }
+        }catch(err){ }
+        return false;
+      };
+      const check = ()=>{
+        if (done) return;
+        if (sheetReady()){ finish(); return; }
+        scheduleCheck();
+      };
+      link.addEventListener('load', finish, { once: true });
+      link.addEventListener('error', finish, { once: true });
+      check();
+    });
+  }
 
   function injectCssOnce(){
     // Try to resolve CSS path from the script src
-    if ([...document.styleSheets].some(s=>s.href && s.href.includes('cart-drawer.css'))) return;
+    if (state.cssReadyConfirmed || state.cssPromise) return;
+    var existing = document.querySelector('link[data-cart-drawer="1"]')
+      || [...document.querySelectorAll('link[rel="stylesheet"]')]
+        .find(l=>l.href && l.href.includes('cart-drawer.css'));
+    if (existing){
+      state.cssReady = false;
+      state.cssPromise = waitForStylesheet(existing).then(()=>{
+        state.cssReady = true;
+        state.cssPromise = null;
+        state.cssReadyConfirmed = true;
+      });
+      return;
+    }
+    if ([...document.styleSheets].some(s=>s.href && s.href.includes('cart-drawer.css'))){
+      state.cssReady = true;
+      state.cssPromise = null;
+      state.cssReadyConfirmed = true;
+      return;
+    }
     var script = [...document.scripts].find(s=>s.src && s.src.includes('cart-drawer.js'));
     var href = '/assets/css/cart-drawer.css';
     if (script){
@@ -119,6 +202,12 @@
     link.href = href;
     link.dataset.cartDrawer = '1';
     document.head.appendChild(link);
+    state.cssReady = false;
+    state.cssPromise = waitForStylesheet(link).then(()=>{
+      state.cssReady = true;
+      state.cssPromise = null;
+      state.cssReadyConfirmed = true;
+    });
   }
 
   function bindSimpleCart(){
@@ -345,31 +434,55 @@
     updateScrollIndicators();
   }
 
-  function open(trigger){
-    if (!ensureReady()) return;
+  function performOpen(trigger){
+    const root = state.root;
+    if (!root) return;
+    state.awaitingCssForOpen = false;
+    state.pendingOpenTrigger = null;
     state.lastTrigger = trigger || document.activeElement;
-    state.root.classList.add('open');
-    state.root.removeAttribute('aria-hidden');
+    root.classList.add('open');
+    root.removeAttribute('aria-hidden');
     const sb = window.innerWidth - document.documentElement.clientWidth;
     document.body.classList.add('drawer-open');
     if(sb > 0) document.body.style.paddingRight = sb + 'px';
     render();
     const live = $('#cart-drawer-live'); if(live){ live.textContent='Added to your cart'; }
-    // Focus first interactive element
-    const first = state.root.querySelector('.cart-drawer-panel .btn, .cart-drawer-panel input, .cart-drawer-panel [href]');
+    const first = root.querySelector('.cart-drawer-panel .btn, .cart-drawer-panel input, .cart-drawer-panel [href]');
     if(first) first.focus();
-    // Auto close on desktop after ~7s (cancel on interaction)
     clearTimeout(state.autoCloseTimer);
     if (window.matchMedia('(min-width: 769px)').matches){
       state.autoCloseTimer = setTimeout(()=>CartDrawer.close(), 7000);
-      state.root.addEventListener('pointerdown', cancelAutoCloseOnce, { once: true });
-      state.root.addEventListener('keydown', cancelAutoCloseOnce, { once: true });
+      root.addEventListener('pointerdown', cancelAutoCloseOnce, { once: true });
+      root.addEventListener('keydown', cancelAutoCloseOnce, { once: true });
     }
-    // Optional: bump cart badge
     try{
       const badge = document.querySelector('[data-cart-badge], .simpleCart_quantity');
       if (badge){ badge.classList.add('cart-bump'); setTimeout(()=>badge.classList.remove('cart-bump'), 400); }
-    }catch(_){}
+    }catch(_){ }
+  }
+
+  function open(trigger){
+    if (!ensureReady()) return;
+    if (!state.cssReady){
+      state.pendingOpenTrigger = typeof trigger === 'undefined' ? document.activeElement : trigger;
+      state.awaitingCssForOpen = true;
+      if (state.cssPromise && !state.cssPromiseHandlerAttached){
+        state.cssPromiseHandlerAttached = true;
+        state.cssPromise.then(()=>{
+          state.cssPromiseHandlerAttached = false;
+          if (!state.awaitingCssForOpen) return;
+          waitForFrames().then(()=>{
+            if (!state.awaitingCssForOpen) return;
+            const pending = state.pendingOpenTrigger;
+            state.pendingOpenTrigger = null;
+            state.awaitingCssForOpen = false;
+            performOpen(pending);
+          });
+        });
+      }
+      return;
+    }
+    performOpen(trigger);
   }
   function cancelAutoCloseOnce(){ clearTimeout(state.autoCloseTimer); }
   function close(){


### PR DESCRIPTION
## Summary
- add a waitForFrames helper so the cart drawer waits a couple frames after CSS readiness
- refactor opening logic into performOpen and delay queued opens until styles are applied before animating

## Testing
- npm run lint:static

------
https://chatgpt.com/codex/tasks/task_e_68d1a7586ef8832082c0d04fc044d258