### PR TITLE
Add update mechanism: network-first service worker + "Update available" banner

### DIFF
--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -73,6 +73,87 @@ window.track = window.track || function (type, data) {
   } catch (e) { console.warn('analytics error', e); }
 };
 
+// ── App updates: service worker + "Update available" banner ───────────────
+// Registers the network-first service worker (sw.js) so online visitors always
+// get the latest code and the site works offline. When a new version is
+// deployed (sw.js VERSION bumped), a small non-intrusive banner invites the
+// customer to refresh into the new version.
+(function () {
+  if (!('serviceWorker' in navigator)) return;
+
+  function showUpdateBanner(applyUpdate) {
+    if (document.getElementById('app-update-banner')) return;
+    if (!document.body) { document.addEventListener('DOMContentLoaded', function () { showUpdateBanner(applyUpdate); }, { once: true }); return; }
+    var style = document.getElementById('app-update-style');
+    if (!style) {
+      style = document.createElement('style');
+      style.id = 'app-update-style';
+      style.textContent =
+        '#app-update-banner{position:fixed;left:50%;transform:translateX(-50%);bottom:16px;z-index:2147483000;' +
+        'background:#111;color:#fff;border-radius:12px;padding:10px 12px 10px 16px;display:flex;gap:12px;align-items:center;' +
+        'box-shadow:0 8px 28px rgba(0,0,0,.28);font:500 14px/1.25 Inter,system-ui,Arial,sans-serif;max-width:92vw}' +
+        '#app-update-banner button{border:0;border-radius:8px;padding:8px 12px;font-weight:600;cursor:pointer;font-size:14px}' +
+        '#app-update-banner .au-refresh{background:#fff;color:#111}' +
+        '#app-update-banner .au-later{background:transparent;color:#bbb}';
+      document.head.appendChild(style);
+    }
+    var bar = document.createElement('div');
+    bar.id = 'app-update-banner';
+    bar.setAttribute('role', 'status');
+    bar.setAttribute('aria-live', 'polite');
+    var msg = document.createElement('span');
+    msg.textContent = 'A new version of the site is available.';
+    var refresh = document.createElement('button');
+    refresh.className = 'au-refresh';
+    refresh.textContent = 'Refresh';
+    refresh.onclick = function () { refresh.disabled = true; applyUpdate(); };
+    var later = document.createElement('button');
+    later.className = 'au-later';
+    later.textContent = 'Later';
+    later.onclick = function () { bar.remove(); };
+    bar.appendChild(msg); bar.appendChild(refresh); bar.appendChild(later);
+    document.body.appendChild(bar);
+  }
+
+  var updateAccepted = false; // set when the customer taps Refresh
+
+  window.addEventListener('load', function () {
+    navigator.serviceWorker.register('/sw.js').then(function (reg) {
+      function offerUpdate(worker) {
+        showUpdateBanner(function () {
+          updateAccepted = true;
+          (worker || reg.waiting).postMessage({ type: 'SKIP_WAITING' });
+        });
+      }
+      // A worker is already waiting from a previous visit.
+      if (reg.waiting && navigator.serviceWorker.controller) offerUpdate(reg.waiting);
+      // A new worker starts installing while the page is open.
+      reg.addEventListener('updatefound', function () {
+        var nw = reg.installing;
+        if (!nw) return;
+        nw.addEventListener('statechange', function () {
+          if (nw.state === 'installed' && navigator.serviceWorker.controller) offerUpdate(nw);
+        });
+      });
+      // Check for a new version now and whenever the tab regains focus.
+      try { reg.update(); } catch (e) {}
+      document.addEventListener('visibilitychange', function () {
+        if (!document.hidden) { try { reg.update(); } catch (e) {} }
+      });
+    }).catch(function () {});
+
+    // When the new worker takes control AFTER the customer accepted the update,
+    // reload once to run the fresh code. (Ignore the first-visit claim, which
+    // also fires controllerchange but should not reload the page.)
+    var reloaded = false;
+    navigator.serviceWorker.addEventListener('controllerchange', function () {
+      if (reloaded || !updateAccepted) return;
+      reloaded = true;
+      window.location.reload();
+    });
+  });
+})();
+
 $(function() {
   // Initialize simpleCart
   simpleCart({

--- a/assets/js/storefront-runtime.js
+++ b/assets/js/storefront-runtime.js
@@ -137,8 +137,5 @@ if (!window.StorefrontRuntime) {
   };
   })();
 }
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch(() => {});
-  });
-}
+// Service worker registration + update banner live in assets/js/config.js
+// (loaded on every page), so it is not duplicated here.

--- a/assets/js/tabs.js
+++ b/assets/js/tabs.js
@@ -96,7 +96,7 @@
     nav.classList.toggle('bnz-tabs--center', shouldCenter);
   }
 
-document.addEventListener('DOMContentLoaded', async function(){
+(function(run){ if(document.readyState==='loading') document.addEventListener('DOMContentLoaded', run, {once:true}); else run(); })(async function(){
     try{
       const raw = await loadCategories();
       if (raw && raw.length){
@@ -120,7 +120,7 @@ document.addEventListener('DOMContentLoaded', async function(){
 })();
 
 // Load search autocomplete module on every page
-document.addEventListener('DOMContentLoaded', function(){
+(function(run){ if(document.readyState==='loading') document.addEventListener('DOMContentLoaded', run, {once:true}); else run(); })(function(){
   const s = document.createElement('script');
   s.type = 'module';
   s.src = '/assets/js/search-autocomplete.js';

--- a/sw.js
+++ b/sw.js
@@ -1,31 +1,77 @@
-const CACHE_NAME = 'image-cache-v1';
+// 4D Cosmetics service worker.
+//
+// ── HOW UPDATES REACH CUSTOMERS ───────────────────────────────────────────
+// Bump VERSION below on every deploy. Because this file's bytes change, the
+// browser detects a new service worker, installs it, and the site shows an
+// "Update available" banner (see assets/js/config.js). The customer taps
+// Refresh and gets the new version. Online visitors are always served fresh
+// (network-first); the cache is only used as an offline fallback.
+const VERSION = '2026.06.28-1';
+const RUNTIME = 'runtime-' + VERSION; // HTML / JS / CSS / JSON (network-first)
+const IMAGES = 'image-cache-v1';      // product images (cache-first, long-lived)
 
-self.addEventListener('install', event => {
-  self.skipWaiting();
+self.addEventListener('install', () => {
+  // Intentionally do NOT skipWaiting here. The new worker waits so the page can
+  // offer the "Update available" banner; skipWaiting runs when the user accepts.
 });
 
-self.addEventListener('activate', event => {
-  event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
-    )
-  );
-  self.clients.claim();
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') self.skipWaiting();
 });
 
-self.addEventListener('fetch', event => {
-  const request = event.request;
-  if (request.destination === 'image') {
+self.addEventListener('activate', (event) => {
+  event.waitUntil((async () => {
+    const keep = new Set([RUNTIME, IMAGES]);
+    const keys = await caches.keys();
+    await Promise.all(keys.filter((k) => !keep.has(k)).map((k) => caches.delete(k)));
+    await self.clients.claim();
+  })());
+});
+
+self.addEventListener('fetch', (event) => {
+  const req = event.request;
+  if (req.method !== 'GET') return;
+
+  let url;
+  try { url = new URL(req.url); } catch (e) { return; }
+
+  // Leave cross-origin requests (Google Fonts, Font Awesome CDN, WhatsApp, …)
+  // entirely alone.
+  if (url.origin !== self.location.origin) return;
+
+  // Images: cache-first for speed (they rarely change).
+  if (req.destination === 'image') {
     event.respondWith(
-      caches.open(CACHE_NAME).then(cache =>
-        cache.match(request).then(resp => {
-          if (resp) return resp;
-          return fetch(request).then(networkResp => {
-            cache.put(request, networkResp.clone());
-            return networkResp;
-          });
-        })
+      caches.open(IMAGES).then((cache) =>
+        cache.match(req).then((hit) =>
+          hit || fetch(req).then((res) => { if (res && res.ok) cache.put(req, res.clone()); return res; })
+        )
       )
     );
+    return;
   }
+
+  // Everything else same-origin (page navigations, JS, CSS, JSON):
+  // NETWORK-FIRST — always try the network first so online visitors get the
+  // latest code; only fall back to the cache when the network is unavailable.
+  event.respondWith((async () => {
+    try {
+      const res = await fetch(req);
+      // Cache a copy for offline use. For navigations we cache even the
+      // GitHub-Pages 404 SPA shell so /p/ and /c/ pages work offline too.
+      if (res && (res.ok || req.mode === 'navigate')) {
+        const cache = await caches.open(RUNTIME);
+        cache.put(req, res.clone());
+      }
+      return res;
+    } catch (err) {
+      const cached = await caches.match(req);
+      if (cached) return cached;
+      if (req.mode === 'navigate') {
+        const home = (await caches.match('/index.html')) || (await caches.match('/'));
+        if (home) return home;
+      }
+      throw err;
+    }
+  })());
 });

--- a/version.json
+++ b/version.json
@@ -1,0 +1,4 @@
+{
+  "version": "2026.06.28-1",
+  "note": "Keep this in sync with VERSION in sw.js. Bump both on every deploy so returning visitors are offered the update."
+}


### PR DESCRIPTION
## Why
Returning customers could load an old cached version of the site. This adds a controlled update path so they reliably get the latest version, plus offline support.

## What
- **`sw.js` → network-first service worker.** Online visitors always get the latest code from the network; the cache is only an **offline fallback**. Product images stay cache-first for speed. Only same-origin requests are handled — Google Fonts / Font Awesome CDN / WhatsApp are untouched. Old version caches are cleared on activate.
- **`config.js` → registration + "Update available" banner.** Registers the SW (on every page) and, when a new version is deployed, shows a small non-intrusive banner with **Refresh** / **Later**. Driven by the SW update lifecycle; guarded so the first-visit SW claim doesn't reload the page. Tapping Refresh activates the new worker and reloads once.
- **`version.json`** added as a human-readable version marker.
- **`storefront-runtime.js`** — removed the now-duplicate SW registration.
- **`tabs.js`** — initialise immediately when the DOM is already parsed (not only on the `DOMContentLoaded` event), so it works when loaded dynamically. Fixes the category nav not rendering on the genuine 404 page.

## Deploy workflow (important)
On each deploy, **bump `VERSION` in `sw.js`** (and `version.json` to match). Changing `sw.js` is what makes the browser detect a new version and show customers the update banner.

## Verification (headless)
- SW registers, controls the page, and **serves it offline** from cache.
- Simulated deploy (sw.js bytes change) → **Update banner appears**; **Refresh** activates the new worker and reloads.
- No first-visit reload (guarded).
- Cart works on home / PDP / search / collection; `/p/` and `/c/` drawer opens and stays via the GitHub Pages fallback.
- All 19 page types load with **zero console/page errors**; genuine 404 now builds its nav.

## Safety / rollback
Network-first means a bad deploy is self-correcting (online users fetch fresh next load). If the SW itself ever needed disabling, deploying a minimal "unregister" `sw.js` is the escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKV8JvqEeSHhbUVVtwdo9u)_