### PR TITLE
Add Pages CMS for no-code product entry

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -1,0 +1,194 @@
+# Pages CMS configuration — https://pagescms.org
+#
+# This powers a friendly, no-code admin form for adding/editing products.
+# A team member signs in at https://app.pagescms.org with their (free) GitHub
+# account, picks this repo, and gets a form instead of raw JSON.
+#
+# It reads/writes assets/data/products.json and uploads images into
+# assets/img/products/ — the same files the live site already uses.
+# Field names below intentionally match assets/schemas/products.schema.json,
+# so anything saved here passes the CI data-validation check.
+
+media:
+  - name: product-images
+    label: Product images
+    input: assets/img/products
+    output: /assets/img/products
+    extensions: [jpg, jpeg, png, webp, avif]
+
+content:
+  - name: products
+    label: Products
+    type: file
+    path: assets/data/products.json
+    list: true
+    # Columns shown in the list view:
+    view:
+      fields: [name, brand, inStock]
+      primary: name
+    fields:
+      - name: id
+        label: Internal ID (auto-generated — do not edit)
+        type: uuid
+
+      - name: name
+        label: Product name
+        type: string
+        required: true
+        description: The full product name shown to customers.
+
+      - name: slug
+        label: URL slug
+        type: string
+        required: true
+        description: >-
+          Lowercase words separated by hyphens, e.g. "rbory-face-primer".
+          This becomes the product's web address (/p/<slug>). Keep it unique.
+        options:
+          pattern:
+            regex: "^[a-z0-9-]+$"
+            message: Use only lowercase letters, numbers, and hyphens (no spaces).
+
+      - name: images
+        label: Product images
+        type: image
+        list: true
+        required: true
+        options:
+          media: product-images
+        description: The first image is used as the main thumbnail.
+
+      - name: price
+        label: Price
+        type: object
+        fields:
+          - name: current
+            label: Price (PKR)
+            type: number
+            required: true
+          - name: old
+            label: Old price (optional — shows a strike-through discount)
+            type: number
+          - name: currency
+            label: Currency
+            type: select
+            default: PKR
+            required: true
+            options:
+              values: [PKR]
+
+      - name: categories
+        label: Categories
+        type: select
+        list: true
+        required: true
+        description: Pick the top-level category plus any sub-category that fits.
+        options:
+          multiple: true
+          values:
+            - { value: makeup, label: "Makeup (top-level)" }
+            - { value: skin-care, label: "Skin Care (top-level)" }
+            - { value: hair-care, label: "Hair Care (top-level)" }
+            - { value: primer, label: "— Primer" }
+            - { value: foundation, label: "— Foundation" }
+            - { value: contour-concealer, label: "— Contour & Concealer" }
+            - { value: highlighter, label: "— Highlighter" }
+            - { value: face-powder, label: "— Face powder" }
+            - { value: blush, label: "— Blush" }
+            - { value: lipsticks, label: "— Lipsticks" }
+            - { value: eye-shadow, label: "— Eye shadow" }
+            - { value: eye-liner, label: "— Eye liner" }
+            - { value: mascara, label: "— Mascara" }
+            - { value: serums, label: "— Serums (Skin Care)" }
+            - { value: creams, label: "— Creams (Skin Care)" }
+
+      - name: brand
+        label: Brand
+        type: string
+
+      - name: shortDescription
+        label: Short description
+        type: text
+        required: true
+        description: One line shown on product cards and search results.
+
+      - name: descriptionHTML
+        label: Full description
+        type: text
+        required: true
+        description: >-
+          The description shown on the product page. Plain text is fine.
+          Basic HTML tags (e.g. <p>, <b>, <br>) also work if you know them.
+
+      - name: inStock
+        label: In stock?
+        type: boolean
+        default: true
+
+      - name: tags
+        label: Tags (optional)
+        type: string
+        list: true
+        description: Short keywords, e.g. "matte", "non-greasy".
+
+      - name: sku
+        label: SKU (optional)
+        type: string
+        description: Your own product/stock code, if you use one.
+
+      # ---- Optional richer product-page fields (leave blank if not needed) ----
+      - name: details
+        label: Product details (optional)
+        type: string
+        list: true
+        description: Bullet points listed on the product page.
+
+      - name: howTo
+        label: How to use (optional)
+        type: string
+        list: true
+
+      - name: ingredients
+        label: Ingredients (optional)
+        type: text
+
+      - name: goodToKnow
+        label: Good to know (optional)
+        type: text
+
+      - name: shippingReturns
+        label: Shipping & returns (optional)
+        type: text
+
+      # ---- Variants (optional; only for products sold in shades/colours) ----
+      - name: variants
+        label: Variants (optional — shades / colours)
+        type: object
+        list: true
+        fields:
+          - name: id
+            label: Variant ID
+            type: string
+            required: true
+          - name: name
+            label: Variant name
+            type: string
+            required: true
+          - name: color
+            label: Colour (hex or name)
+            type: string
+          - name: image
+            label: Variant image
+            type: image
+            options:
+              media: product-images
+          - name: price
+            label: Variant price (PKR)
+            type: number
+          - name: inStock
+            label: Variant in stock?
+            type: boolean
+            default: true
+          - name: sku
+            label: Variant SKU
+            type: string

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,17 @@ deployed from the **`master`** branch.
    - Search (`/search/`): `search-page.js` + `search.js` (+ `search-autocomplete.js`, lazy-loaded by `tabs.js`)
    - PDP (`/p/`): `pdp.js` + `pdp-hydrate.js`
 
+## Content editing (adding products)
+
+Non-technical team members add/edit products through **Pages CMS**
+(https://app.pagescms.org) — a hosted, no-code form over this repo. Config lives
+in `.pages.yml` at the repo root; its field names mirror
+`assets/schemas/products.schema.json`, so saved entries pass CI data validation.
+It reads/writes `assets/data/products.json` and uploads images into
+`assets/img/products/`. Editors sign in with their own free GitHub accounts
+(added as free collaborators — unlimited on private repos). See
+`docs/adding-products.md` for the editor-facing guide.
+
 ## Cart & checkout (the one canonical flow)
 
 There is **one** cart pipeline. Earlier scattered/legacy cart code has been removed.

--- a/docs/adding-products.md
+++ b/docs/adding-products.md
@@ -1,0 +1,78 @@
+# Adding products — guide for the team
+
+We add and edit products through **Pages CMS**, a simple web form. You do **not**
+need to know GitHub, JSON, or coding. Everything you save here goes into the
+website automatically.
+
+---
+
+## One-time setup (per person)
+
+1. Create a **free** GitHub account at <https://github.com/signup> (if you don't
+   have one). It costs nothing.
+2. Send your GitHub username to the site owner so they can add you as a
+   collaborator on the `chatdroidab/4dcosmetics` repository.
+3. Once added, go to <https://app.pagescms.org> and click **Sign in with
+   GitHub**. Approve the access it asks for.
+4. Pick the **4dcosmetics** repository from the list. You'll land on the
+   **Products** screen.
+
+That's it — from now on you just visit <https://app.pagescms.org> to work.
+
+---
+
+## Adding a new product
+
+1. Open **Products** in the left menu.
+2. Click **Add an entry** (top right).
+3. Fill in the form:
+
+   | Field | What to put |
+   |-------|-------------|
+   | **Internal ID** | Leave it — it fills in automatically. |
+   | **Product name** | The full name, e.g. *RBory Face Primer*. |
+   | **URL slug** | Lowercase words with hyphens, e.g. `rbory-face-primer`. Must be unique. |
+   | **Product images** | Click to upload one or more photos. The **first** one is the main thumbnail. |
+   | **Price (PKR)** | The selling price, numbers only (e.g. `2500`). |
+   | **Old price** | Optional. Fill this to show a crossed-out discount. |
+   | **Categories** | Tick the top-level category (Makeup / Skin Care / Hair Care) **and** the sub-category that fits. |
+   | **Brand** | Brand name (optional). |
+   | **Short description** | One line shown on product cards. |
+   | **Full description** | The longer description on the product page. Plain text is fine. |
+   | **In stock?** | On by default. Turn off if sold out. |
+   | Tags / SKU / Details / etc. | All optional — fill only if useful. |
+
+4. Click **Save**.
+
+### About the photos
+
+- Upload straight from your phone or computer — no need to rename files.
+- Landscape or square photos on a clean background look best.
+- You can add several images; drag to reorder. First = main image.
+
+---
+
+## Editing or marking something out of stock
+
+1. Open **Products**, click the product in the list.
+2. Change what you need — price, description, or switch **In stock?** off.
+3. Click **Save**.
+
+---
+
+## What happens after you save
+
+- Your change is saved to the website's files automatically.
+- The live site (**4dcosmetics.com**) updates within a couple of minutes.
+- If the site owner has turned on review-before-publish, your change waits for a
+  quick approval first — you'll be told if that's the case.
+
+---
+
+## Tips & rules
+
+- **Slug must be unique** and use only lowercase letters, numbers, and hyphens.
+  The form will warn you if it's wrong.
+- **Price is numbers only** — don't type "Rs" or commas (`2500`, not `2,500`).
+- If something looks broken after saving, tell the site owner — nothing you do
+  here can break the site permanently; it can always be undone.


### PR DESCRIPTION
Add a hosted, no-code admin form (Pages CMS) so non-technical team
members can add and edit products without touching JSON or git.

- .pages.yml: maps the product schema to a friendly form (category
  dropdowns, drag-and-drop image upload into assets/img/products/,
  auto-generated internal IDs, slug pattern validation). Field names
  mirror assets/schemas/products.schema.json so saved entries pass CI
  data validation.
- docs/adding-products.md: editor-facing guide.
- CLAUDE.md: document the content-editing workflow.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011aRNjHakxzefUGUtqs7s6a